### PR TITLE
feat(cli): Rework prune and self-update to respect installation style

### DIFF
--- a/cli/cmd/logging.go
+++ b/cli/cmd/logging.go
@@ -8,9 +8,9 @@ import (
 )
 
 // activateLogging opens the log file and configures the output printer's log writer.
-// If logFilePath is set, it uses that directly. Otherwise, it derives the log path
-// from the project cache directory. If both are empty, no log file is opened.
-func activateLogging(logFilePath string, projectCachePath string) {
+// If logFilePath is set, it uses that directly. Otherwise, it writes a timestamped
+// log file into logDir. If both are empty, no log file is opened.
+func activateLogging(logFilePath string, logDir string) {
 	var logPath string
 	var err error
 
@@ -19,8 +19,8 @@ func activateLogging(logFilePath string, projectCachePath string) {
 		if _, err = log.OpenLogFileAt(logPath); err != nil {
 			out.Fatalf("Failed to open log file: %s", err)
 		}
-	} else if projectCachePath != "" {
-		logPath, err = log.OpenProjectLog(projectCachePath)
+	} else if logDir != "" {
+		logPath, err = log.OpenProjectLog(logDir)
 		if err != nil {
 			out.Fatalf("Failed to open project log file: %s", err)
 		}
@@ -32,13 +32,12 @@ func activateLogging(logFilePath string, projectCachePath string) {
 	}
 }
 
-// activateLoggingForProject resolves the project cache path from projectPath,
-// then activates logging. Used by compile and project commands that share the
-// same "resolve cache path → activate logging" pattern.
+// activateLoggingForProject resolves the project log directory from projectPath,
+// then activates logging. Logs are written to ~/.opentaint/logs/<slug-hash>/.
 func activateLoggingForProject(logFilePath string, projectPath string) {
-	cachePath, err := utils.GetProjectCachePath(projectPath)
+	logPath, err := utils.GetProjectLogPath(projectPath)
 	if err != nil {
-		output.LogInfof("Failed to resolve project cache path for logging: %v", err)
+		output.LogInfof("Failed to resolve project log path: %v", err)
 	}
-	activateLogging(logFilePath, cachePath)
+	activateLogging(logFilePath, logPath)
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -35,24 +35,22 @@ func resolveCategories() (utils.PruneCategory, error) {
 		return utils.PruneCategoriesDefault, nil
 	}
 
+	flagMap := []struct {
+		flag *bool
+		cat  utils.PruneCategory
+	}{
+		{&pruneArtifacts, utils.PruneCategoryArtifacts},
+		{&pruneRules, utils.PruneCategoryRules},
+		{&pruneJDK, utils.PruneCategoryJDK},
+		{&pruneModels, utils.PruneCategoryModels},
+		{&pruneLogs, utils.PruneCategoryLogs},
+		{&pruneInstall, utils.PruneCategoryInstall},
+	}
 	var cats utils.PruneCategory
-	if pruneArtifacts {
-		cats |= utils.PruneCategoryArtifacts
-	}
-	if pruneRules {
-		cats |= utils.PruneCategoryRules
-	}
-	if pruneJDK {
-		cats |= utils.PruneCategoryJDK
-	}
-	if pruneModels {
-		cats |= utils.PruneCategoryModels
-	}
-	if pruneLogs {
-		cats |= utils.PruneCategoryLogs
-	}
-	if pruneInstall {
-		cats |= utils.PruneCategoryInstall
+	for _, f := range flagMap {
+		if *f.flag {
+			cats |= f.cat
+		}
 	}
 	return cats, nil
 }
@@ -73,7 +71,7 @@ Use category flags to prune selectively:
   --jdk         Old JDK/JRE versions
   --models      Cached project models and staging directories
   --logs        Project log files
-  --install     Install-tier lib and JRE artifacts
+  --install     Install-tier lib and JRE artifacts (requires re-download)
 
 Without category flags, prunes: artifacts + rules + jdk + models.
 With --all: prunes everything including logs and install-tier.`,
@@ -162,5 +160,5 @@ func init() {
 	pruneCmd.Flags().BoolVar(&pruneJDK, "jdk", false, "Prune old JDK/JRE versions")
 	pruneCmd.Flags().BoolVar(&pruneModels, "models", false, "Prune cached project models and staging directories")
 	pruneCmd.Flags().BoolVar(&pruneLogs, "logs", false, "Prune project log files")
-	pruneCmd.Flags().BoolVar(&pruneInstall, "install", false, "Prune install-tier lib and JRE artifacts")
+	pruneCmd.Flags().BoolVar(&pruneInstall, "install", false, "Prune install-tier lib and JRE artifacts (requires re-download on next run)")
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -9,10 +9,9 @@ import (
 )
 
 var (
-	pruneDryRun  bool
-	pruneYes     bool
-	pruneIncLogs bool
-	pruneAll     bool
+	pruneDryRun bool
+	pruneYes    bool
+	pruneAll    bool
 )
 
 var pruneCmd = &cobra.Command{
@@ -23,12 +22,9 @@ var pruneCmd = &cobra.Command{
 Identifies artifacts that are no longer needed:
 - Old versions of analyzer JARs, autobuilder JARs, and rules
 - Downloaded JDK/JRE versions that don't match the current version
-- Redundant downloads when bundled artifacts are available
-- With --all: install-tier lib and JRE artifacts
-
-By default, log files are kept. Use --include-logs to also prune them from project cache directories.`,
+- With --all: install-tier lib and JRE artifacts, and log files from project cache directories`,
 	Run: func(cmd *cobra.Command, args []string) {
-		result, err := utils.ScanForStaleArtifacts(pruneIncLogs, pruneAll)
+		result, err := utils.ScanForStaleArtifacts(pruneAll)
 		if err != nil {
 			out.Fatalf("Failed to scan for stale artifacts: %s", err)
 		}
@@ -71,6 +67,5 @@ func init() {
 
 	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted without deleting")
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Skip interactive confirmation")
-	pruneCmd.Flags().BoolVar(&pruneIncLogs, "include-logs", false, "Also prune log files")
-	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier JRE and lib artifacts")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier artifacts and log files")
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -22,7 +22,7 @@ var pruneCmd = &cobra.Command{
 Identifies artifacts that are no longer needed:
 - Old versions of analyzer JARs, autobuilder JARs, and rules
 - Downloaded JDK/JRE versions that don't match the current version
-- With --all: install-tier lib and JRE artifacts, and log files from project cache directories`,
+- With --all: install-tier lib and JRE artifacts, and entire project cache directories (including logs)`,
 	Run: func(cmd *cobra.Command, args []string) {
 		result, err := utils.ScanForStaleArtifacts(pruneAll)
 		if err != nil {
@@ -67,5 +67,5 @@ func init() {
 
 	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted without deleting")
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Skip interactive confirmation")
-	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier artifacts and log files")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier artifacts and entire project cache directories (including logs)")
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -12,6 +12,7 @@ var (
 	pruneDryRun  bool
 	pruneYes     bool
 	pruneIncLogs bool
+	pruneAll     bool
 )
 
 var pruneCmd = &cobra.Command{
@@ -23,11 +24,12 @@ Identifies artifacts that are no longer needed:
 - Old versions of analyzer JARs, autobuilder JARs, and rules
 - Downloaded JDK/JRE versions that don't match the current version
 - Redundant downloads when bundled artifacts are available
-- Stale install-tier artifacts (~/.opentaint/install/) after a opentaint upgrade
+- Stale install-tier lib artifacts (~/.opentaint/install/) after a opentaint upgrade
+- With --all: install-tier JRE and lib artifacts regardless of upgrade state
 
 By default, log files are kept. Use --include-logs to also prune them from project cache directories.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		result, err := utils.ScanForStaleArtifacts(pruneIncLogs)
+		result, err := utils.ScanForStaleArtifacts(pruneIncLogs, pruneAll)
 		if err != nil {
 			out.Fatalf("Failed to scan for stale artifacts: %s", err)
 		}
@@ -71,4 +73,5 @@ func init() {
 	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted without deleting")
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Skip interactive confirmation")
 	pruneCmd.Flags().BoolVar(&pruneIncLogs, "include-logs", false, "Also prune log files")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier JRE and lib artifacts")
 }

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -24,8 +24,7 @@ Identifies artifacts that are no longer needed:
 - Old versions of analyzer JARs, autobuilder JARs, and rules
 - Downloaded JDK/JRE versions that don't match the current version
 - Redundant downloads when bundled artifacts are available
-- Stale install-tier lib artifacts (~/.opentaint/install/) after a opentaint upgrade
-- With --all: install-tier JRE and lib artifacts regardless of upgrade state
+- With --all: install-tier lib and JRE artifacts
 
 By default, log files are kept. Use --include-logs to also prune them from project cache directories.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cli/cmd/prune.go
+++ b/cli/cmd/prune.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/seqra/opentaint/internal/output"
 	"github.com/seqra/opentaint/internal/utils"
@@ -9,10 +10,52 @@ import (
 )
 
 var (
-	pruneDryRun bool
-	pruneYes    bool
-	pruneAll    bool
+	pruneDryRun    bool
+	pruneYes       bool
+	pruneAll       bool
+	pruneArtifacts bool
+	pruneRules     bool
+	pruneJDK       bool
+	pruneModels    bool
+	pruneLogs      bool
+	pruneInstall   bool
 )
+
+// resolveCategories maps CLI flags to a PruneCategory bitmask.
+// Returns an error if --all is combined with specific flags.
+func resolveCategories() (utils.PruneCategory, error) {
+	specific := pruneArtifacts || pruneRules || pruneJDK || pruneModels || pruneLogs || pruneInstall
+	if pruneAll && specific {
+		return 0, fmt.Errorf("--all cannot be combined with specific category flags (--artifacts, --rules, --jdk, --models, --logs, --install)")
+	}
+	if pruneAll {
+		return utils.PruneCategoriesAll, nil
+	}
+	if !specific {
+		return utils.PruneCategoriesDefault, nil
+	}
+
+	var cats utils.PruneCategory
+	if pruneArtifacts {
+		cats |= utils.PruneCategoryArtifacts
+	}
+	if pruneRules {
+		cats |= utils.PruneCategoryRules
+	}
+	if pruneJDK {
+		cats |= utils.PruneCategoryJDK
+	}
+	if pruneModels {
+		cats |= utils.PruneCategoryModels
+	}
+	if pruneLogs {
+		cats |= utils.PruneCategoryLogs
+	}
+	if pruneInstall {
+		cats |= utils.PruneCategoryInstall
+	}
+	return cats, nil
+}
 
 var pruneCmd = &cobra.Command{
 	Use:   "prune",
@@ -22,11 +65,57 @@ var pruneCmd = &cobra.Command{
 Identifies artifacts that are no longer needed:
 - Old versions of analyzer JARs, autobuilder JARs, and rules
 - Downloaded JDK/JRE versions that don't match the current version
-- With --all: install-tier lib and JRE artifacts, and entire project cache directories (including logs)`,
+- Cached project models and staging directories
+
+Use category flags to prune selectively:
+  --artifacts   Stale analyzer and autobuilder JARs
+  --rules       Stale rules directories
+  --jdk         Old JDK/JRE versions
+  --models      Cached project models and staging directories
+  --logs        Project log files
+  --install     Install-tier lib and JRE artifacts
+
+Without category flags, prunes: artifacts + rules + jdk + models.
+With --all: prunes everything including logs and install-tier.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		result, err := utils.ScanForStaleArtifacts(pruneAll)
+		categories, err := resolveCategories()
+		if err != nil {
+			out.FatalErr(err)
+		}
+
+		// Acquire global prune lock
+		pruneLockPath, err := utils.PruneLockPath()
+		if err != nil {
+			out.Fatalf("Failed to resolve prune lock path: %s", err)
+		}
+		pruneLock, err := utils.TryLock(pruneLockPath, utils.LockMeta{
+			PID:     os.Getpid(),
+			Command: "prune",
+		})
+		if err == utils.ErrLocked {
+			out.Fatal("Another prune is already running")
+		}
+		if err != nil {
+			out.Fatalf("Failed to acquire prune lock: %s", err)
+		}
+		defer pruneLock.Unlock()
+
+		result, err := utils.ScanForStaleArtifacts(categories)
 		if err != nil {
 			out.Fatalf("Failed to scan for stale artifacts: %s", err)
+		}
+
+		// Display skipped projects
+		if len(result.Skipped) > 0 {
+			sb := out.Section("Skipped (compilation in progress)")
+			for _, s := range result.Skipped {
+				if s.Meta.PID != 0 {
+					sb.Text(fmt.Sprintf("%s (locked by PID %d)", s.Path, s.Meta.PID))
+				} else {
+					sb.Text(fmt.Sprintf("%s (locked)", s.Path))
+				}
+			}
+			sb.Render()
 		}
 
 		if result.TotalCount == 0 {
@@ -67,5 +156,11 @@ func init() {
 
 	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted without deleting")
 	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Skip interactive confirmation")
-	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Also prune install-tier artifacts and entire project cache directories (including logs)")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune everything including logs and install-tier artifacts")
+	pruneCmd.Flags().BoolVar(&pruneArtifacts, "artifacts", false, "Prune stale analyzer and autobuilder JARs")
+	pruneCmd.Flags().BoolVar(&pruneRules, "rules", false, "Prune stale rules directories")
+	pruneCmd.Flags().BoolVar(&pruneJDK, "jdk", false, "Prune old JDK/JRE versions")
+	pruneCmd.Flags().BoolVar(&pruneModels, "models", false, "Prune cached project models and staging directories")
+	pruneCmd.Flags().BoolVar(&pruneLogs, "logs", false, "Prune project log files")
+	pruneCmd.Flags().BoolVar(&pruneInstall, "install", false, "Prune install-tier lib and JRE artifacts")
 }

--- a/cli/cmd/pull.go
+++ b/cli/cmd/pull.go
@@ -125,7 +125,7 @@ func downloadJava(installNextToBinary, installCurrent bool) (*tree.Tree, error) 
 		return node, fmt.Errorf("unsupported Java version: %d (supported range: 8-25)", javaVersion)
 	}
 
-	opentaintHome, err := utils.GetOpentaintHome()
+	opentaintHome, err := utils.GetOpenTaintHome()
 	if err != nil {
 		return node, err
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -187,7 +187,7 @@ func checkForUpdateAsync() {
 		return
 	}
 
-	opentaintHome, err := utils.GetOpentaintHome()
+	opentaintHome, err := utils.GetOpenTaintHome()
 	if err != nil {
 		return
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -48,6 +48,9 @@ var rootCmd = &cobra.Command{
 		out.Configure(globals.Config.Log.Color, globals.Config.Quiet)
 		out.SetVerbosity(globals.Config.Log.Verbosity)
 
+		// Reconcile install-tier version marker if needed (lightweight: a few Stat calls).
+		utils.ReconcileInstallMarker()
+
 		// Start async update check (non-blocking, at most once per day)
 		if !globals.Config.Quiet {
 			go checkForUpdateAsync()

--- a/cli/cmd/scan.go
+++ b/cli/cmd/scan.go
@@ -69,6 +69,7 @@ type scanConfig struct {
 	projectCachePath string // cache dir for this project (empty for explicit model / dry-run)
 	stagingDir       string // staging dir path (empty when not compiling or dry-run)
 	needsCompilation bool   // true when compilation is needed before scanning
+	compileLock      *utils.FileLock
 }
 
 // scanCmd represents the scan command
@@ -159,6 +160,11 @@ func scan(cmd *cobra.Command) {
 	}
 
 	cfg := resolveScanConfig(absUserProjectRoot)
+	defer func() {
+		if cfg.compileLock != nil {
+			cfg.compileLock.Unlock()
+		}
+	}()
 
 	// Activate logging
 	if !DryRunScan {
@@ -418,10 +424,17 @@ func resolveScanConfig(absUserProjectRoot string) scanConfig {
 		}
 	}
 
-	if utils.HasStagingDir(projectCachePath) {
+	compileLock, lockErr := utils.TryLock(
+		utils.CompileLockPath(projectCachePath),
+		utils.LockMeta{PID: os.Getpid(), Command: "compile", Project: absUserProjectRoot},
+	)
+	if lockErr == utils.ErrLocked {
 		out.Error("Compilation already in progress for this project")
 		suggest("To scan an existing model instead", utils.NewScanCommand("").WithProjectModel("<model-path>").Build())
 		os.Exit(1)
+	}
+	if lockErr != nil {
+		out.Fatalf("Failed to acquire compile lock: %s", lockErr)
 	}
 
 	stagingDir, serr := utils.CreateStagingDir(projectCachePath)
@@ -435,6 +448,7 @@ func resolveScanConfig(absUserProjectRoot string) scanConfig {
 		projectCachePath: projectCachePath,
 		stagingDir:       stagingDir,
 		needsCompilation: true,
+		compileLock:      compileLock,
 	}
 }
 

--- a/cli/cmd/scan.go
+++ b/cli/cmd/scan.go
@@ -162,11 +162,7 @@ func scan(cmd *cobra.Command) {
 
 	// Activate logging
 	if !DryRunScan {
-		if cfg.projectCachePath != "" {
-			activateLogging(ScanLogFile, cfg.projectCachePath)
-		} else {
-			activateLoggingForProject(ScanLogFile, absUserProjectRoot)
-		}
+		activateLoggingForProject(ScanLogFile, absUserProjectRoot)
 	}
 
 	absProjectModelPath := cfg.absProjectModel

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -132,7 +132,7 @@ Only upgrades are supported — downgrading to an older version is refused.`,
 
 		// Auto-prune after successful update
 		out.Print("Pruning stale artifacts...")
-		pruneResult, err := utils.ScanForStaleArtifacts(false, false)
+		pruneResult, err := utils.ScanForStaleArtifacts(false)
 		if err != nil {
 			out.Warnf("Failed to scan for stale artifacts: %s", err)
 			return

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -128,6 +128,7 @@ Only upgrades are supported — downgrading to an older version is refused.`,
 		}
 
 		out.Successf("Successfully updated to v%s", targetVersion)
+		suggest("To clean up old artifacts run", "opentaint prune")
 	},
 }
 

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -132,7 +132,7 @@ Only upgrades are supported — downgrading to an older version is refused.`,
 
 		// Auto-prune after successful update
 		out.Print("Pruning stale artifacts...")
-		pruneResult, err := utils.ScanForStaleArtifacts(false)
+		pruneResult, err := utils.ScanForStaleArtifacts(false, false)
 		if err != nil {
 			out.Warnf("Failed to scan for stale artifacts: %s", err)
 			return

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/seqra/opentaint/internal/globals"
-	"github.com/seqra/opentaint/internal/output"
 	"github.com/seqra/opentaint/internal/utils"
 	"github.com/seqra/opentaint/internal/version"
 	"github.com/spf13/cobra"
@@ -129,21 +128,6 @@ Only upgrades are supported — downgrading to an older version is refused.`,
 		}
 
 		out.Successf("Successfully updated to v%s", targetVersion)
-
-		// Auto-prune after successful update
-		out.Print("Pruning stale artifacts...")
-		pruneResult, err := utils.ScanForStaleArtifacts(false)
-		if err != nil {
-			out.Warnf("Failed to scan for stale artifacts: %s", err)
-			return
-		}
-		if pruneResult.TotalCount > 0 {
-			if err := utils.DeleteArtifacts(pruneResult.Stale); err != nil {
-				out.Warnf("Failed to prune stale artifacts: %s", err)
-			} else {
-				out.Successf("Pruned %d items, freed %s", pruneResult.TotalCount, output.FormatSize(pruneResult.TotalSize))
-			}
-		}
 	},
 }
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -48,7 +49,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -42,6 +42,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -106,6 +108,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/cli/internal/utils/java/runner.go
+++ b/cli/internal/utils/java/runner.go
@@ -372,7 +372,7 @@ func (j *javaRunner) ensureSpecificVersion(version int) (string, error) {
 	// Unset Java environment variables for clean environment when using specific version
 	unsetJavaEnvironmentVariables()
 
-	opentaintHome, err := utils.GetOpentaintHome()
+	opentaintHome, err := utils.GetOpenTaintHome()
 	if err != nil {
 		return "", err
 	}

--- a/cli/internal/utils/lock.go
+++ b/cli/internal/utils/lock.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gofrs/flock"
+)
+
+// ErrLocked is returned when a lock file is already held by another process.
+var ErrLocked = errors.New("lock is held by another process")
+
+// LockMeta holds diagnostic information written into lock files.
+type LockMeta struct {
+	PID     int
+	Command string
+	Project string
+}
+
+// FileLock wraps a flock.Flock with its path for cleanup.
+type FileLock struct {
+	flock *flock.Flock
+	path  string
+}
+
+// Unlock releases the advisory lock and removes the lock file.
+func (l *FileLock) Unlock() {
+	_ = l.flock.Unlock()
+	_ = os.Remove(l.path)
+}
+
+// TryLock attempts a non-blocking exclusive lock on the given path.
+// On success it writes meta into the file and returns a FileLock.
+// On failure because the lock is held, it returns ErrLocked.
+func TryLock(lockPath string, meta LockMeta) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create lock directory: %w", err)
+	}
+
+	fl := flock.New(lockPath)
+	locked, err := fl.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	if !locked {
+		return nil, ErrLocked
+	}
+
+	content := fmt.Sprintf("pid=%d\ncommand=%s\n", meta.PID, meta.Command)
+	if meta.Project != "" {
+		content += fmt.Sprintf("project=%s\n", meta.Project)
+	}
+	_ = os.WriteFile(lockPath, []byte(content), 0o644)
+
+	return &FileLock{flock: fl, path: lockPath}, nil
+}
+
+// ReadLockMeta reads diagnostic metadata from a lock file.
+func ReadLockMeta(lockPath string) (LockMeta, error) {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return LockMeta{}, err
+	}
+	var meta LockMeta
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "pid":
+			meta.PID, _ = strconv.Atoi(value)
+		case "command":
+			meta.Command = value
+		case "project":
+			meta.Project = value
+		}
+	}
+	return meta, nil
+}
+
+// PruneLockPath returns the path to the global prune lock: ~/.opentaint/.prune.lock
+func PruneLockPath() (string, error) {
+	home, err := GetOpenTaintHomePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".prune.lock"), nil
+}
+
+// CompileLockPath returns the path to a per-project compile lock:
+// <projectCachePath>/.compile.lock
+func CompileLockPath(projectCachePath string) string {
+	return filepath.Join(projectCachePath, ".compile.lock")
+}

--- a/cli/internal/utils/lock_test.go
+++ b/cli/internal/utils/lock_test.go
@@ -1,0 +1,102 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTryLock(t *testing.T) {
+	t.Run("acquires lock on new file", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "test"})
+		if err != nil {
+			t.Fatalf("TryLock() error = %v", err)
+		}
+		defer lock.Unlock()
+	})
+
+	t.Run("second lock on same file returns ErrLocked", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock1, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "first"})
+		if err != nil {
+			t.Fatalf("first TryLock() error = %v", err)
+		}
+		defer lock1.Unlock()
+
+		_, err = TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "second"})
+		if err != ErrLocked {
+			t.Fatalf("expected ErrLocked, got %v", err)
+		}
+	})
+
+	t.Run("lock released after Unlock allows re-acquisition", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock1, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "first"})
+		if err != nil {
+			t.Fatalf("first TryLock() error = %v", err)
+		}
+		lock1.Unlock()
+
+		lock2, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "second"})
+		if err != nil {
+			t.Fatalf("second TryLock() error = %v", err)
+		}
+		defer lock2.Unlock()
+	})
+}
+
+func TestReadLockMeta(t *testing.T) {
+	t.Run("reads PID and command from lock file", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		meta := LockMeta{PID: 12345, Command: "compile", Project: "/tmp/my-project"}
+		lock, err := TryLock(lockPath, meta)
+		if err != nil {
+			t.Fatalf("TryLock() error = %v", err)
+		}
+		defer lock.Unlock()
+
+		got, err := ReadLockMeta(lockPath)
+		if err != nil {
+			t.Fatalf("ReadLockMeta() error = %v", err)
+		}
+		if got.PID != 12345 {
+			t.Errorf("PID = %d, want 12345", got.PID)
+		}
+		if got.Command != "compile" {
+			t.Errorf("Command = %q, want %q", got.Command, "compile")
+		}
+		if got.Project != "/tmp/my-project" {
+			t.Errorf("Project = %q, want %q", got.Project, "/tmp/my-project")
+		}
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		_, err := ReadLockMeta(filepath.Join(t.TempDir(), "missing.lock"))
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+
+func TestPruneLockPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	lockPath, err := PruneLockPath()
+	if err != nil {
+		t.Fatalf("PruneLockPath() error = %v", err)
+	}
+	expected := filepath.Join(home, ".opentaint", ".prune.lock")
+	if lockPath != expected {
+		t.Errorf("got %q, want %q", lockPath, expected)
+	}
+}
+
+func TestCompileLockPath(t *testing.T) {
+	result := CompileLockPath("/home/user/.opentaint/cache/my-project-abc12345")
+	expected := "/home/user/.opentaint/cache/my-project-abc12345/.compile.lock"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}

--- a/cli/internal/utils/log/project_log.go
+++ b/cli/internal/utils/log/project_log.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-// OpenProjectLog opens a timestamped log file under <cacheDir>/logs/ and swaps
+// OpenProjectLog opens a timestamped log file directly inside logDir and swaps
 // the global SwitchableWriter to write to it. Returns the log file path.
-func OpenProjectLog(cacheDir string) (string, error) {
-	logPath := filepath.Join(cacheDir, "logs", time.Now().Format("2006-01-02_15-04-05.log"))
+func OpenProjectLog(logDir string) (string, error) {
+	logPath := filepath.Join(logDir, time.Now().Format("2006-01-02_15-04-05.log"))
 	if _, err := OpenLogFileAt(logPath); err != nil {
 		return "", err
 	}

--- a/cli/internal/utils/log/project_log_test.go
+++ b/cli/internal/utils/log/project_log_test.go
@@ -8,24 +8,28 @@ import (
 )
 
 func TestOpenProjectLog(t *testing.T) {
-	t.Run("creates log file under cache slug dir", func(t *testing.T) {
+	t.Run("creates log file directly inside logDir", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 
-		cacheDir := filepath.Join(home, ".opentaint", "cache", "my-project-abc12345")
-		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		logDir := filepath.Join(home, ".opentaint", "logs", "my-project-abc12345")
+		if err := os.MkdirAll(logDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 
-		logPath, err := OpenProjectLog(cacheDir)
+		logPath, err := OpenProjectLog(logDir)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		defer func() { _ = CloseLogFile() }()
 
-		logsDir := filepath.Join(cacheDir, "logs")
-		if !strings.HasPrefix(logPath, logsDir) {
-			t.Errorf("log path %q should be under %q", logPath, logsDir)
+		if !strings.HasPrefix(logPath, logDir) {
+			t.Errorf("log path %q should be directly under %q", logPath, logDir)
+		}
+
+		// Ensure no extra "logs/" subdirectory was created
+		if strings.HasPrefix(logPath, filepath.Join(logDir, "logs")) {
+			t.Errorf("log path %q should NOT be under %q/logs — logDir is already the logs dir", logPath, logDir)
 		}
 
 		if _, err := os.Stat(logPath); err != nil {

--- a/cli/internal/utils/model_cache.go
+++ b/cli/internal/utils/model_cache.go
@@ -14,7 +14,7 @@ var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
 // GetModelCacheDirPath returns ~/.opentaint/cache/ without creating it.
 // Use this when you only need to read/check the directory (e.g. prune scanning).
 func GetModelCacheDirPath() (string, error) {
-	opentaintHome, err := GetOpentaintHome()
+	opentaintHome, err := GetOpenTaintHomePath()
 	if err != nil {
 		return "", err
 	}

--- a/cli/internal/utils/model_cache.go
+++ b/cli/internal/utils/model_cache.go
@@ -62,7 +62,37 @@ func GetProjectCachePath(projectPath string) (string, error) {
 const (
 	projectModelDir = "project-model"
 	modelsCacheDir  = "cache"
+	logsCacheDir    = "logs"
 )
+
+// GetLogCacheDirPath returns ~/.opentaint/logs/ without creating it.
+func GetLogCacheDirPath() (string, error) {
+	opentaintHome, err := GetOpenTaintHomePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(opentaintHome, logsCacheDir), nil
+}
+
+// GetProjectLogPath returns ~/.opentaint/logs/<slug-hash>/ for a project path,
+// without creating the directory. The project path is canonicalized before hashing.
+func GetProjectLogPath(projectPath string) (string, error) {
+	absPath, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	logsDir, err := GetLogCacheDirPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(logsDir, ProjectPathSlugHash(absPath)), nil
+}
 
 // DefaultSarifReportPath returns the default SARIF report location for a given
 // project model path: <projectModelPath>/sources/opentaint.sarif

--- a/cli/internal/utils/model_cache.go
+++ b/cli/internal/utils/model_cache.go
@@ -118,8 +118,7 @@ func CreateStagingDir(cacheDir string) (string, error) {
 
 // PromoteStagingToCache moves the compiled project-model/ from the staging
 // directory into the cache, replacing any existing cached model.
-// HasStagingDir provides best-effort detection of concurrent compilations
-// (not a lock), so in practice only one process promotes at a time.
+// The caller must hold the compile lock to prevent concurrent promotions.
 func PromoteStagingToCache(cacheDir, stagingPath string) error {
 	srcPM := filepath.Join(stagingPath, projectModelDir)
 	destPM := filepath.Join(cacheDir, projectModelDir)
@@ -138,22 +137,6 @@ func PromoteStagingToCache(cacheDir, stagingPath string) error {
 	_ = os.RemoveAll(stagingPath)
 
 	return nil
-}
-
-// HasStagingDir checks whether any .staging-* directory exists in cacheDir.
-// This is a best-effort heuristic (not a lock) for detecting in-progress
-// compilations; a TOCTOU race is possible but unlikely for a CLI tool.
-func HasStagingDir(cacheDir string) bool {
-	entries, err := os.ReadDir(cacheDir)
-	if err != nil {
-		return false
-	}
-	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), ".staging-") {
-			return true
-		}
-	}
-	return false
 }
 
 // CleanupStagingDir removes a staging directory and all its contents.

--- a/cli/internal/utils/model_cache.go
+++ b/cli/internal/utils/model_cache.go
@@ -33,10 +33,8 @@ func GetModelCacheDir() (string, error) {
 	return modelsDir, nil
 }
 
-// GetProjectCachePath returns ~/.opentaint/cache/<slug-hash>/ for a project path,
-// creating the directory if needed. The project path is canonicalized (resolved
-// through symlinks and made absolute) before hashing.
-func GetProjectCachePath(projectPath string) (string, error) {
+// canonicalProjectPath resolves a project path to an absolute, symlink-resolved form.
+func canonicalProjectPath(projectPath string) (string, error) {
 	absPath, err := filepath.Abs(projectPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
@@ -44,6 +42,17 @@ func GetProjectCachePath(projectPath string) (string, error) {
 	absPath, err = filepath.EvalSymlinks(absPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+	return absPath, nil
+}
+
+// GetProjectCachePath returns ~/.opentaint/cache/<slug-hash>/ for a project path,
+// creating the directory if needed. The project path is canonicalized (resolved
+// through symlinks and made absolute) before hashing.
+func GetProjectCachePath(projectPath string) (string, error) {
+	absPath, err := canonicalProjectPath(projectPath)
+	if err != nil {
+		return "", err
 	}
 
 	modelsDir, err := GetModelCacheDir()
@@ -77,13 +86,9 @@ func GetLogCacheDirPath() (string, error) {
 // GetProjectLogPath returns ~/.opentaint/logs/<slug-hash>/ for a project path,
 // without creating the directory. The project path is canonicalized before hashing.
 func GetProjectLogPath(projectPath string) (string, error) {
-	absPath, err := filepath.Abs(projectPath)
+	absPath, err := canonicalProjectPath(projectPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
-	}
-	absPath, err = filepath.EvalSymlinks(absPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+		return "", err
 	}
 
 	logsDir, err := GetLogCacheDirPath()

--- a/cli/internal/utils/model_cache_test.go
+++ b/cli/internal/utils/model_cache_test.go
@@ -284,3 +284,44 @@ func TestCleanupStagingDir(t *testing.T) {
 		t.Error("staging dir should be removed after cleanup")
 	}
 }
+
+func TestGetLogCacheDirPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logDir, err := GetLogCacheDirPath()
+	if err != nil {
+		t.Fatalf("GetLogCacheDirPath() error = %v", err)
+	}
+	expected := filepath.Join(home, ".opentaint", "logs")
+	if logDir != expected {
+		t.Errorf("got %q, want %q", logDir, expected)
+	}
+}
+
+func TestGetProjectLogPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Use a real existing path so EvalSymlinks works.
+	// projectPath is passed as-is; GetProjectLogPath canonicalizes it internally.
+	// The slug-hash is computed from the resolved path, so we resolve here too.
+	projectPath := home
+	resolvedProjectPath, err := filepath.EvalSymlinks(projectPath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks projectPath: %v", err)
+	}
+
+	logPath, err := GetProjectLogPath(projectPath)
+	if err != nil {
+		t.Fatalf("GetProjectLogPath() error = %v", err)
+	}
+
+	// GetOpenTaintHomePath uses os.UserHomeDir() which returns HOME as-is (unresolved).
+	// So the logs base is HOME/.opentaint/logs, not resolved-HOME/.opentaint/logs.
+	slugHash := ProjectPathSlugHash(resolvedProjectPath)
+	expected := filepath.Join(home, ".opentaint", "logs", slugHash)
+	if logPath != expected {
+		t.Errorf("got %q, want %q", logPath, expected)
+	}
+}

--- a/cli/internal/utils/opentaint_home.go
+++ b/cli/internal/utils/opentaint_home.go
@@ -25,6 +25,12 @@ func GetOpentaintHome() (string, error) {
 	return path, nil
 }
 
+// pathExists reports whether a path exists on disk.
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
 // exeDir returns the directory containing the current executable, resolved through symlinks.
 // Returns empty string if the path cannot be determined.
 func exeDir() string {
@@ -125,6 +131,26 @@ func CleanInstallDir() error {
 		}
 	}
 	return nil
+}
+
+// ReconcileInstallMarker writes the install-tier version marker if all
+// bind-version artifacts are present but the marker is missing or stale.
+// This reconciles the marker after SelfUpdate, where the old binary cannot
+// write correct data. Safe to call on every command invocation (a few Stat calls).
+func ReconcileInstallMarker() {
+	if IsInstallCurrent() {
+		return
+	}
+	installLib := GetInstallLibPath()
+	if installLib == "" {
+		return
+	}
+	for _, def := range globals.Artifacts() {
+		if !pathExists(filepath.Join(installLib, def.LibSubpath)) {
+			return
+		}
+	}
+	_ = WriteInstallVersionMarker()
 }
 
 // resolveArtifactPath resolves the path for an artifact by checking tiers in order:

--- a/cli/internal/utils/opentaint_home.go
+++ b/cli/internal/utils/opentaint_home.go
@@ -8,20 +8,25 @@ import (
 	"github.com/seqra/opentaint/internal/globals"
 )
 
-func GetOpentaintHome() (string, error) {
-	// Find home directory.
+// GetOpenTaintHomePath returns ~/.opentaint/ without creating it.
+// Use this when you only need to read/check the directory (e.g. prune scanning).
+func GetOpenTaintHomePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
+	return filepath.Join(home, ".opentaint"), nil
+}
 
-	// Search config in home directory with name ".opentaint" (without extension).
-	path := filepath.Join(home, ".opentaint")
-	merr := os.MkdirAll(path, os.ModePerm)
-	if merr != nil {
-		return "", merr
+// GetOpenTaintHome returns ~/.opentaint/, creating it if needed.
+func GetOpenTaintHome() (string, error) {
+	path, err := GetOpenTaintHomePath()
+	if err != nil {
+		return "", err
 	}
-
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		return "", err
+	}
 	return path, nil
 }
 

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -203,8 +203,7 @@ func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
 		modelsDir, mErr := GetModelCacheDirPath()
 		if mErr != nil {
 			output.LogDebugf("Failed to resolve model cache path: %v", mErr)
-		}
-		if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
+		} else if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
 			modelEntries, err := os.ReadDir(modelsDir)
 			if err == nil {
 				for _, modelEntry := range modelEntries {

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -36,6 +36,13 @@ type PruneResult struct {
 	TotalCount int
 }
 
+// Add appends a stale artifact and updates the totals.
+func (r *PruneResult) Add(a StaleArtifact) {
+	r.Stale = append(r.Stale, a)
+	r.TotalSize += a.Size
+	r.TotalCount++
+}
+
 // checkStale tests whether a filename matches the given artifact definition and
 // has a version that differs from the bind version.
 // Returns a StaleArtifact if it should be pruned, nil otherwise.
@@ -88,9 +95,7 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 		matched := false
 		for _, def := range artifacts {
 			if artifact := checkStale(def, name, fullPath); artifact != nil {
-				result.Stale = append(result.Stale, *artifact)
-				result.TotalSize += artifact.Size
-				result.TotalCount++
+				result.Add(*artifact)
 				matched = true
 				break
 			}
@@ -116,13 +121,7 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 				}
 				subPath := filepath.Join(fullPath, subEntry.Name())
 				size, _ := dirSize(subPath)
-				result.Stale = append(result.Stale, StaleArtifact{
-					Path: subPath,
-					Size: size,
-					Kind: name,
-				})
-				result.TotalSize += size
-				result.TotalCount++
+				result.Add(StaleArtifact{Path: subPath, Size: size, Kind: name})
 			}
 			continue
 		}
@@ -144,13 +143,7 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 			continue
 		}
 		size, _ := dirSize(check.path)
-		result.Stale = append(result.Stale, StaleArtifact{
-			Path: check.path,
-			Size: size,
-			Kind: check.kind,
-		})
-		result.TotalSize += size
-		result.TotalCount++
+		result.Add(StaleArtifact{Path: check.path, Size: size, Kind: check.kind})
 	}
 
 	// Scan for cached compilation models (and optionally logs inside them)
@@ -165,13 +158,7 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 				modelPath := filepath.Join(modelsDir, modelEntry.Name())
 				size, _ := dirSize(modelPath)
 				if size > 0 {
-					result.Stale = append(result.Stale, StaleArtifact{
-						Path: modelPath,
-						Size: size,
-						Kind: StaleKindModel,
-					})
-					result.TotalSize += size
-					result.TotalCount++
+					result.Add(StaleArtifact{Path: modelPath, Size: size, Kind: StaleKindModel})
 				}
 
 				if all {
@@ -179,13 +166,7 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 					if lInfo, lErr := os.Stat(logsDir); lErr == nil && lInfo.IsDir() {
 						logSize, _ := dirSize(logsDir)
 						if logSize > 0 {
-							result.Stale = append(result.Stale, StaleArtifact{
-								Path: logsDir,
-								Size: logSize,
-								Kind: StaleKindLog,
-							})
-							result.TotalSize += logSize
-							result.TotalCount++
+							result.Add(StaleArtifact{Path: logsDir, Size: logSize, Kind: StaleKindLog})
 						}
 					}
 				}

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -218,10 +218,12 @@ func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
 						result.AddSkipped(SkippedProject{Path: projectCachePath, Meta: meta})
 						continue
 					}
-					if lock != nil {
-						lock.Unlock()
+					if lockErr != nil {
+						output.LogDebugf("Failed to probe compile lock for %s, skipping: %v", projectCachePath, lockErr)
+						continue
 					}
 					scanProjectCacheSubdirs(projectCachePath, result)
+					lock.Unlock()
 				}
 			}
 		}

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/seqra/opentaint/internal/globals"
+	"github.com/seqra/opentaint/internal/output"
 )
 
 // Stale artifact kind constants.
@@ -68,7 +69,7 @@ func checkStale(def globals.ArtifactDef, name, fullPath string) *StaleArtifact {
 
 // ScanForStaleArtifacts scans ~/.opentaint/ for artifacts that are not current and returns them.
 func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
-	opentaintHome, err := GetOpentaintHome()
+	opentaintHome, err := GetOpenTaintHomePath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get opentaint home: %w", err)
 	}
@@ -76,6 +77,9 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 	result := &PruneResult{}
 
 	entries, err := os.ReadDir(opentaintHome)
+	if os.IsNotExist(err) {
+		return result, nil
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read opentaint home: %w", err)
 	}
@@ -147,7 +151,10 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 	}
 
 	// Scan for cached compilation models (and optionally logs inside them)
-	modelsDir, _ := GetModelCacheDirPath()
+	modelsDir, mErr := GetModelCacheDirPath()
+	if mErr != nil {
+		output.LogDebugf("Failed to resolve model cache path: %v", mErr)
+	}
 	if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
 		modelEntries, err := os.ReadDir(modelsDir)
 		if err == nil {
@@ -155,26 +162,44 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 				if !modelEntry.IsDir() {
 					continue
 				}
-				modelPath := filepath.Join(modelsDir, modelEntry.Name())
-				size, _ := dirSize(modelPath)
-				if size > 0 {
-					result.Add(StaleArtifact{Path: modelPath, Size: size, Kind: StaleKindModel})
-				}
-
+				projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
 				if all {
-					logsDir := filepath.Join(modelPath, "logs")
-					if lInfo, lErr := os.Stat(logsDir); lErr == nil && lInfo.IsDir() {
-						logSize, _ := dirSize(logsDir)
-						if logSize > 0 {
-							result.Add(StaleArtifact{Path: logsDir, Size: logSize, Kind: StaleKindLog})
-						}
+					// With --all: prune entire project cache dir (model + logs)
+					size, _ := dirSize(projectCachePath)
+					if size > 0 {
+						result.Add(StaleArtifact{Path: projectCachePath, Size: size, Kind: StaleKindModel})
 					}
+				} else {
+					// Without --all: prune only project-model/ and .staging-* dirs, preserve logs
+					scanProjectCacheSubdirs(projectCachePath, result)
 				}
 			}
 		}
 	}
 
 	return result, nil
+}
+
+// scanProjectCacheSubdirs adds only project-model/ and .staging-* subdirs
+// from a project cache directory, preserving logs and other data.
+func scanProjectCacheSubdirs(projectCachePath string, result *PruneResult) {
+	entries, err := os.ReadDir(projectCachePath)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == projectModelDir || strings.HasPrefix(name, ".staging-") {
+			subPath := filepath.Join(projectCachePath, name)
+			size, _ := dirSize(subPath)
+			if size > 0 {
+				result.Add(StaleArtifact{Path: subPath, Size: size, Kind: StaleKindModel})
+			}
+		}
+	}
 }
 
 // DeleteArtifacts removes the given stale artifacts.

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -60,7 +60,7 @@ func checkStale(def globals.ArtifactDef, name, fullPath string) *StaleArtifact {
 }
 
 // ScanForStaleArtifacts scans ~/.opentaint/ for artifacts that are not current and returns them.
-func ScanForStaleArtifacts(includeLogs, all bool) (*PruneResult, error) {
+func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 	opentaintHome, err := GetOpentaintHome()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get opentaint home: %w", err)
@@ -174,7 +174,7 @@ func ScanForStaleArtifacts(includeLogs, all bool) (*PruneResult, error) {
 					result.TotalCount++
 				}
 
-				if includeLogs {
+				if all {
 					logsDir := filepath.Join(modelPath, "logs")
 					if lInfo, lErr := os.Stat(logsDir); lErr == nil && lInfo.IsDir() {
 						logSize, _ := dirSize(logsDir)

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -274,14 +274,37 @@ func scanProjectCacheSubdirs(projectCachePath string, result *PruneResult) {
 	}
 }
 
-// DeleteArtifacts removes the given stale artifacts.
+// DeleteArtifacts removes the given stale artifacts and cleans up empty parent
+// directories left behind (e.g. empty project cache dirs under ~/.opentaint/cache/).
 func DeleteArtifacts(artifacts []StaleArtifact) error {
+	emptyDirCandidates := map[string]struct{}{}
+
 	for _, artifact := range artifacts {
 		if err := os.RemoveAll(artifact.Path); err != nil {
 			return fmt.Errorf("failed to remove %s: %w", artifact.Path, err)
 		}
+		if artifact.Kind == StaleKindModel || artifact.Kind == StaleKindLog {
+			emptyDirCandidates[filepath.Dir(artifact.Path)] = struct{}{}
+		}
+	}
+
+	// Try to remove empty parent directories bottom-up.
+	// os.Remove only succeeds on empty directories, so this is safe.
+	for dir := range emptyDirCandidates {
+		removeEmptyParents(dir)
 	}
 	return nil
+}
+
+// removeEmptyParents attempts to remove dir and its parent if they are empty.
+// Stops at the first non-empty or non-removable directory.
+func removeEmptyParents(dir string) {
+	for i := 0; i < 2; i++ {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+		dir = filepath.Dir(dir)
+	}
 }
 
 func fileSize(path string) int64 {

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -30,9 +30,16 @@ type StaleArtifact struct {
 	Kind string
 }
 
+// SkippedProject represents a project cache that was skipped because a compile lock was held.
+type SkippedProject struct {
+	Path string
+	Meta LockMeta
+}
+
 // PruneResult contains the results of scanning for stale artifacts.
 type PruneResult struct {
 	Stale      []StaleArtifact
+	Skipped    []SkippedProject
 	TotalSize  int64
 	TotalCount int
 }
@@ -42,6 +49,11 @@ func (r *PruneResult) Add(a StaleArtifact) {
 	r.Stale = append(r.Stale, a)
 	r.TotalSize += a.Size
 	r.TotalCount++
+}
+
+// AddSkipped records a project that was skipped due to an active compile lock.
+func (r *PruneResult) AddSkipped(s SkippedProject) {
+	r.Skipped = append(r.Skipped, s)
 }
 
 // PruneCategory represents a class of artifacts that can be selectively pruned.
@@ -186,12 +198,13 @@ func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
 		}
 	}
 
-	// Scan for cached compilation models
+	// Models (cache dir) — lock-aware
 	if categories.has(PruneCategoryModels) {
 		modelsDir, mErr := GetModelCacheDirPath()
 		if mErr != nil {
 			output.LogDebugf("Failed to resolve model cache path: %v", mErr)
-		} else if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
+		}
+		if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
 			modelEntries, err := os.ReadDir(modelsDir)
 			if err == nil {
 				for _, modelEntry := range modelEntries {
@@ -199,8 +212,16 @@ func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
 						continue
 					}
 					projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
-					// Always prune only project-model/ and .staging-* subdirs;
-					// logs are now in a separate ~/.opentaint/logs/ directory.
+					lockPath := CompileLockPath(projectCachePath)
+					lock, lockErr := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "prune"})
+					if lockErr == ErrLocked {
+						meta, _ := ReadLockMeta(lockPath)
+						result.AddSkipped(SkippedProject{Path: projectCachePath, Meta: meta})
+						continue
+					}
+					if lock != nil {
+						lock.Unlock()
+					}
 					scanProjectCacheSubdirs(projectCachePath, result)
 				}
 			}

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -44,6 +44,29 @@ func (r *PruneResult) Add(a StaleArtifact) {
 	r.TotalCount++
 }
 
+// PruneCategory represents a class of artifacts that can be selectively pruned.
+type PruneCategory int
+
+const (
+	PruneCategoryArtifacts PruneCategory = 1 << iota
+	PruneCategoryRules
+	PruneCategoryJDK
+	PruneCategoryModels
+	PruneCategoryLogs
+	PruneCategoryInstall
+)
+
+// PruneCategoriesDefault is the set pruned with no flags: artifacts + rules + jdk + models.
+const PruneCategoriesDefault = PruneCategoryArtifacts | PruneCategoryRules | PruneCategoryJDK | PruneCategoryModels
+
+// PruneCategoriesAll is the set pruned with --all.
+const PruneCategoriesAll = PruneCategoryArtifacts | PruneCategoryRules | PruneCategoryJDK | PruneCategoryModels | PruneCategoryLogs | PruneCategoryInstall
+
+// has reports whether the given category is included in the set.
+func (c PruneCategory) has(cat PruneCategory) bool {
+	return c&cat != 0
+}
+
 // checkStale tests whether a filename matches the given artifact definition and
 // has a version that differs from the bind version.
 // Returns a StaleArtifact if it should be pruned, nil otherwise.
@@ -68,7 +91,7 @@ func checkStale(def globals.ArtifactDef, name, fullPath string) *StaleArtifact {
 }
 
 // ScanForStaleArtifacts scans ~/.opentaint/ for artifacts that are not current and returns them.
-func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
+func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
 	opentaintHome, err := GetOpenTaintHomePath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get opentaint home: %w", err)
@@ -76,102 +99,129 @@ func ScanForStaleArtifacts(all bool) (*PruneResult, error) {
 
 	result := &PruneResult{}
 
-	entries, err := os.ReadDir(opentaintHome)
-	if os.IsNotExist(err) {
-		return result, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to read opentaint home: %w", err)
-	}
+	scanArtifactsOrRules := categories.has(PruneCategoryArtifacts) || categories.has(PruneCategoryRules)
+	scanJDK := categories.has(PruneCategoryJDK)
 
-	artifacts := globals.Artifacts()
-
-	for _, entry := range entries {
-		name := entry.Name()
-		fullPath := filepath.Join(opentaintHome, name)
-
-		// Skip special files, hidden files, and cache directory
-		if name == "cache" || strings.HasPrefix(name, ".") {
-			continue
+	if scanArtifactsOrRules || scanJDK {
+		entries, err := os.ReadDir(opentaintHome)
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read opentaint home: %w", err)
 		}
 
-		// Check against artifact definitions
-		matched := false
-		for _, def := range artifacts {
-			if artifact := checkStale(def, name, fullPath); artifact != nil {
-				result.Add(*artifact)
-				matched = true
-				break
-			}
-			if strings.HasPrefix(name, def.CachePrefix) {
-				matched = true // matches pattern but is current — skip
-				break
-			}
-		}
-		if matched {
-			continue
-		}
+		artifacts := globals.Artifacts()
 
-		// Check JDK/JRE directories
-		if name == StaleKindJDK || name == StaleKindJRE {
-			subEntries, err := os.ReadDir(fullPath)
-			if err != nil {
+		for _, entry := range entries {
+			name := entry.Name()
+			fullPath := filepath.Join(opentaintHome, name)
+
+			// Skip special dirs and hidden files
+			if name == "cache" || name == "logs" || name == "install" || strings.HasPrefix(name, ".") {
 				continue
 			}
-			currentPrefix := fmt.Sprintf("temurin-%d-", globals.DefaultJavaVersion)
-			for _, subEntry := range subEntries {
-				if strings.HasPrefix(subEntry.Name(), currentPrefix) {
+
+			if scanArtifactsOrRules {
+				// Check against artifact definitions
+				matched := false
+				for _, def := range artifacts {
+					isRules := def.Kind() == StaleKindRules
+					categoryEnabled := (isRules && categories.has(PruneCategoryRules)) ||
+						(!isRules && categories.has(PruneCategoryArtifacts))
+
+					if strings.HasPrefix(name, def.CachePrefix) {
+						matched = true
+						if categoryEnabled {
+							if artifact := checkStale(def, name, fullPath); artifact != nil {
+								result.Add(*artifact)
+							}
+						}
+						break
+					}
+				}
+				if matched {
 					continue
 				}
-				subPath := filepath.Join(fullPath, subEntry.Name())
-				size, _ := dirSize(subPath)
-				result.Add(StaleArtifact{Path: subPath, Size: size, Kind: name})
 			}
-			continue
+
+			if scanJDK {
+				// Check JDK/JRE directories
+				if name == StaleKindJDK || name == StaleKindJRE {
+					subEntries, err := os.ReadDir(fullPath)
+					if err != nil {
+						continue
+					}
+					currentPrefix := fmt.Sprintf("temurin-%d-", globals.DefaultJavaVersion)
+					for _, subEntry := range subEntries {
+						if strings.HasPrefix(subEntry.Name(), currentPrefix) {
+							continue
+						}
+						subPath := filepath.Join(fullPath, subEntry.Name())
+						size, _ := dirSize(subPath)
+						result.Add(StaleArtifact{Path: subPath, Size: size, Kind: name})
+					}
+				}
+			}
 		}
 	}
 
 	// Scan install-tier directories for stale artifacts
-	for _, check := range []struct {
-		path   string
-		kind   string
-		should bool
-	}{
-		{GetInstallLibPath(), StaleKindInstallLib, all},
-		{GetInstallJREPath(), StaleKindInstallJRE, all},
-	} {
-		if !check.should || check.path == "" {
-			continue
+	if categories.has(PruneCategoryInstall) {
+		for _, check := range []struct {
+			path string
+			kind string
+		}{
+			{GetInstallLibPath(), StaleKindInstallLib},
+			{GetInstallJREPath(), StaleKindInstallJRE},
+		} {
+			if check.path == "" {
+				continue
+			}
+			if _, err := os.Stat(check.path); err != nil {
+				continue
+			}
+			size, _ := dirSize(check.path)
+			result.Add(StaleArtifact{Path: check.path, Size: size, Kind: check.kind})
 		}
-		if _, err := os.Stat(check.path); err != nil {
-			continue
-		}
-		size, _ := dirSize(check.path)
-		result.Add(StaleArtifact{Path: check.path, Size: size, Kind: check.kind})
 	}
 
-	// Scan for cached compilation models (and optionally logs inside them)
-	modelsDir, mErr := GetModelCacheDirPath()
-	if mErr != nil {
-		output.LogDebugf("Failed to resolve model cache path: %v", mErr)
-	}
-	if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
-		modelEntries, err := os.ReadDir(modelsDir)
-		if err == nil {
-			for _, modelEntry := range modelEntries {
-				if !modelEntry.IsDir() {
-					continue
-				}
-				projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
-				if all {
-					// With --all: prune entire project cache dir (model + logs)
-					size, _ := dirSize(projectCachePath)
-					if size > 0 {
-						result.Add(StaleArtifact{Path: projectCachePath, Size: size, Kind: StaleKindModel})
+	// Scan for cached compilation models
+	if categories.has(PruneCategoryModels) {
+		modelsDir, mErr := GetModelCacheDirPath()
+		if mErr != nil {
+			output.LogDebugf("Failed to resolve model cache path: %v", mErr)
+		} else if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
+			modelEntries, err := os.ReadDir(modelsDir)
+			if err == nil {
+				for _, modelEntry := range modelEntries {
+					if !modelEntry.IsDir() {
+						continue
 					}
-				} else {
-					// Without --all: prune only project-model/ and .staging-* dirs, preserve logs
+					projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
+					// Always prune only project-model/ and .staging-* subdirs;
+					// logs are now in a separate ~/.opentaint/logs/ directory.
 					scanProjectCacheSubdirs(projectCachePath, result)
+				}
+			}
+		}
+	}
+
+	// Scan for project log directories
+	if categories.has(PruneCategoryLogs) {
+		logsDir, lErr := GetLogCacheDirPath()
+		if lErr != nil {
+			output.LogDebugf("Failed to resolve log cache path: %v", lErr)
+		} else if info, err := os.Stat(logsDir); err == nil && info.IsDir() {
+			logEntries, err := os.ReadDir(logsDir)
+			if err == nil {
+				for _, logEntry := range logEntries {
+					if !logEntry.IsDir() {
+						continue
+					}
+					projectLogPath := filepath.Join(logsDir, logEntry.Name())
+					size, _ := dirSize(projectLogPath)
+					result.Add(StaleArtifact{Path: projectLogPath, Size: size, Kind: StaleKindLog})
 				}
 			}
 		}

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -129,13 +129,12 @@ func ScanForStaleArtifacts(includeLogs, all bool) (*PruneResult, error) {
 	}
 
 	// Scan install-tier directories for stale artifacts
-	installCurrent := IsInstallCurrent()
 	for _, check := range []struct {
 		path   string
 		kind   string
 		should bool
 	}{
-		{GetInstallLibPath(), StaleKindInstallLib, !installCurrent || all},
+		{GetInstallLibPath(), StaleKindInstallLib, all},
 		{GetInstallJREPath(), StaleKindInstallJRE, all},
 	} {
 		if !check.should || check.path == "" {

--- a/cli/internal/utils/prune.go
+++ b/cli/internal/utils/prune.go
@@ -36,19 +36,17 @@ type PruneResult struct {
 	TotalCount int
 }
 
-// checkStale tests whether a filename matches the given artifact definition and is stale or redundant.
+// checkStale tests whether a filename matches the given artifact definition and
+// has a version that differs from the bind version.
 // Returns a StaleArtifact if it should be pruned, nil otherwise.
-func checkStale(def globals.ArtifactDef, name, fullPath string, bundledLibExists bool) *StaleArtifact {
+func checkStale(def globals.ArtifactDef, name, fullPath string) *StaleArtifact {
 	if !strings.HasPrefix(name, def.CachePrefix) || !strings.HasSuffix(name, def.CacheSuffix) {
 		return nil
 	}
 	version := strings.TrimPrefix(name, def.CachePrefix)
 	version = strings.TrimSuffix(version, def.CacheSuffix)
 
-	isStale := version != def.BindVersion
-	isRedundant := !isStale && bundledLibExists
-
-	if !isStale && !isRedundant {
+	if version == def.BindVersion {
 		return nil
 	}
 
@@ -62,7 +60,7 @@ func checkStale(def globals.ArtifactDef, name, fullPath string, bundledLibExists
 }
 
 // ScanForStaleArtifacts scans ~/.opentaint/ for artifacts that are not current and returns them.
-func ScanForStaleArtifacts(includeLogs bool) (*PruneResult, error) {
+func ScanForStaleArtifacts(includeLogs, all bool) (*PruneResult, error) {
 	opentaintHome, err := GetOpentaintHome()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get opentaint home: %w", err)
@@ -73,20 +71,6 @@ func ScanForStaleArtifacts(includeLogs bool) (*PruneResult, error) {
 	entries, err := os.ReadDir(opentaintHome)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read opentaint home: %w", err)
-	}
-
-	bundledLibExists := false
-	if libPath := GetBundledLibPath(); libPath != "" {
-		if _, err := os.Stat(libPath); err == nil {
-			bundledLibExists = true
-		}
-	}
-
-	bundledJREExists := false
-	if jrePath := GetBundledJREPath(); jrePath != "" {
-		if _, err := os.Stat(jrePath); err == nil {
-			bundledJREExists = true
-		}
 	}
 
 	artifacts := globals.Artifacts()
@@ -103,7 +87,7 @@ func ScanForStaleArtifacts(includeLogs bool) (*PruneResult, error) {
 		// Check against artifact definitions
 		matched := false
 		for _, def := range artifacts {
-			if artifact := checkStale(def, name, fullPath, bundledLibExists); artifact != nil {
+			if artifact := checkStale(def, name, fullPath); artifact != nil {
 				result.Stale = append(result.Stale, *artifact)
 				result.TotalSize += artifact.Size
 				result.TotalCount++
@@ -125,26 +109,20 @@ func ScanForStaleArtifacts(includeLogs bool) (*PruneResult, error) {
 			if err != nil {
 				continue
 			}
+			currentPrefix := fmt.Sprintf("temurin-%d-", globals.DefaultJavaVersion)
 			for _, subEntry := range subEntries {
-				subPath := filepath.Join(fullPath, subEntry.Name())
-
-				// If bundled JRE exists, all downloaded JREs for current version are redundant
-				isRedundant := bundledJREExists && name == StaleKindJRE
-
-				// All JDK/JRE directories that aren't the current version are stale
-				currentPrefix := fmt.Sprintf("temurin-%d-", globals.DefaultJavaVersion)
-				isStale := !strings.HasPrefix(subEntry.Name(), currentPrefix)
-
-				if isStale || isRedundant {
-					size, _ := dirSize(subPath)
-					result.Stale = append(result.Stale, StaleArtifact{
-						Path: subPath,
-						Size: size,
-						Kind: name,
-					})
-					result.TotalSize += size
-					result.TotalCount++
+				if strings.HasPrefix(subEntry.Name(), currentPrefix) {
+					continue
 				}
+				subPath := filepath.Join(fullPath, subEntry.Name())
+				size, _ := dirSize(subPath)
+				result.Stale = append(result.Stale, StaleArtifact{
+					Path: subPath,
+					Size: size,
+					Kind: name,
+				})
+				result.TotalSize += size
+				result.TotalCount++
 			}
 			continue
 		}
@@ -153,29 +131,27 @@ func ScanForStaleArtifacts(includeLogs bool) (*PruneResult, error) {
 	// Scan install-tier directories for stale artifacts
 	installCurrent := IsInstallCurrent()
 	for _, check := range []struct {
-		path          string
-		kind          string
-		bundledExists bool
+		path   string
+		kind   string
+		should bool
 	}{
-		{GetInstallLibPath(), StaleKindInstallLib, bundledLibExists},
-		{GetInstallJREPath(), StaleKindInstallJRE, bundledJREExists},
+		{GetInstallLibPath(), StaleKindInstallLib, !installCurrent || all},
+		{GetInstallJREPath(), StaleKindInstallJRE, all},
 	} {
-		if check.path == "" {
+		if !check.should || check.path == "" {
 			continue
 		}
 		if _, err := os.Stat(check.path); err != nil {
 			continue
 		}
-		if !installCurrent || check.bundledExists {
-			size, _ := dirSize(check.path)
-			result.Stale = append(result.Stale, StaleArtifact{
-				Path: check.path,
-				Size: size,
-				Kind: check.kind,
-			})
-			result.TotalSize += size
-			result.TotalCount++
-		}
+		size, _ := dirSize(check.path)
+		result.Stale = append(result.Stale, StaleArtifact{
+			Path: check.path,
+			Size: size,
+			Kind: check.kind,
+		})
+		result.TotalSize += size
+		result.TotalCount++
 	}
 
 	// Scan for cached compilation models (and optionally logs inside them)

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -220,7 +220,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("logs pruned with all flag", func(t *testing.T) {
+	t.Run("logs included in model prune with all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
@@ -230,10 +230,12 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		assertHasKind(t, result, StaleKindLog)
+		// With --all, entire project cache dir is pruned as model (includes logs)
+		assertHasKind(t, result, StaleKindModel)
+		assertNoKind(t, result, StaleKindLog)
 	})
 
-	t.Run("logs not pruned without all flag", func(t *testing.T) {
+	t.Run("logs-only dir not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
@@ -243,6 +245,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		assertNoKind(t, result, StaleKindModel)
 		assertNoKind(t, result, StaleKindLog)
 	})
 
@@ -350,24 +353,100 @@ func TestScanForStaleArtifacts(t *testing.T) {
 func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 	setupPruneTestGlobals(t)
 
-	t.Run("cached model is prunable", func(t *testing.T) {
+	t.Run("cached model is prunable without all", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		modelsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
-		createTestFile(t, filepath.Join(modelsDir, "project-model", "project.yaml"), 50)
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		pmPath := filepath.Join(projectDir, "project-model", "project.yaml")
+		createTestFile(t, pmPath, 50)
 
 		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		assertHasKind(t, result, StaleKindModel)
+		// Should target project-model/ specifically, not the parent dir
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindModel {
+				expected := filepath.Join(projectDir, "project-model")
+				if s.Path != expected {
+					t.Errorf("expected path %q, got %q", expected, s.Path)
+				}
+			}
+		}
+	})
+
+	t.Run("cached model with all prunes entire dir", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
+
+		result, err := ScanForStaleArtifacts(true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindModel)
+		// Should target the entire project cache dir
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindModel {
+				if s.Path != projectDir {
+					t.Errorf("expected path %q, got %q", projectDir, s.Path)
+				}
+			}
+		}
+	})
+
+	t.Run("logs preserved without all flag", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
+		createTestFile(t, filepath.Join(projectDir, "logs", "2026-01-01.log"), 100)
+
+		result, err := ScanForStaleArtifacts(false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindModel)
+		assertNoKind(t, result, StaleKindLog)
+		// Only project-model should be listed, not logs
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindModel && s.Size != 50 {
+				t.Errorf("expected model size 50 (excluding logs), got %d", s.Size)
+			}
+		}
+	})
+
+	t.Run("no size double-counting with all flag", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
+		createTestFile(t, filepath.Join(projectDir, "logs", "2026-01-01.log"), 100)
+
+		result, err := ScanForStaleArtifacts(true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Should have exactly one entry for the entire dir, no separate log entry
+		modelCount := 0
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindModel {
+				modelCount++
+			}
+		}
+		if modelCount != 1 {
+			t.Errorf("expected 1 model entry, got %d", modelCount)
+		}
+		assertNoKind(t, result, StaleKindLog)
 	})
 
 	t.Run("stale staging dir is prunable", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		modelsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
-		stagingDir := filepath.Join(modelsDir, ".staging-12345-9999")
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		stagingDir := filepath.Join(projectDir, ".staging-12345-9999")
 		createTestFile(t, filepath.Join(stagingDir, "project-model", "project.yaml"), 50)
 
 		result, err := ScanForStaleArtifacts(false)
@@ -375,6 +454,14 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		assertHasKind(t, result, StaleKindModel)
+		// Should target the staging dir specifically
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindModel {
+				if s.Path != stagingDir {
+					t.Errorf("expected path %q, got %q", stagingDir, s.Path)
+				}
+			}
+		}
 	})
 
 	t.Run("empty models dir produces no stale", func(t *testing.T) {
@@ -396,7 +483,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 	setupPruneTestGlobals(t)
 
-	t.Run("logs inside project cache prunable with all flag", func(t *testing.T) {
+	t.Run("logs-only cache dir pruned with all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
@@ -406,10 +493,11 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		assertHasKind(t, result, StaleKindLog)
+		// With --all, the entire project cache dir is pruned (includes logs)
+		assertHasKind(t, result, StaleKindModel)
 	})
 
-	t.Run("logs not pruned without all flag", func(t *testing.T) {
+	t.Run("logs-only cache dir not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
@@ -419,6 +507,8 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		// Without --all, only project-model/ and .staging-* are pruned; logs are preserved
+		assertNoKind(t, result, StaleKindModel)
 		assertNoKind(t, result, StaleKindLog)
 	})
 }

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -559,6 +559,21 @@ func TestScanForStaleArtifacts_Categories(t *testing.T) {
 	})
 }
 
+func TestPruneResult_AddSkipped(t *testing.T) {
+	result := &PruneResult{}
+	result.AddSkipped(SkippedProject{
+		Path: "/home/user/.opentaint/cache/my-project-abc12345",
+		Meta: LockMeta{PID: 12345, Command: "compile"},
+	})
+
+	if len(result.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
+	}
+	if result.Skipped[0].Meta.PID != 12345 {
+		t.Errorf("expected PID 12345, got %d", result.Skipped[0].Meta.PID)
+	}
+}
+
 func createTestFile(t *testing.T, path string, size int) {
 	t.Helper()
 	dir := filepath.Dir(path)

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -67,7 +67,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 
 	t.Run("empty home", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,7 +82,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -100,7 +100,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_1.0.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -115,7 +115,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
 		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -153,7 +153,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jdkDir := filepath.Join(opentaintHome, "jdk", "temurin-17-jdk+35")
 		createTestFile(t, filepath.Join(jdkDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-17-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -191,7 +191,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-21-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -200,13 +200,13 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("logs includeLogs=true", func(t *testing.T) {
+	t.Run("logs pruned with all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
 
-		result, err := ScanForStaleArtifacts(true, false)
+		result, err := ScanForStaleArtifacts(true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -217,23 +217,23 @@ func TestScanForStaleArtifacts(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Error("expected log stale entry when includeLogs=true")
+			t.Error("expected log stale entry with --all flag")
 		}
 	})
 
-	t.Run("logs includeLogs=false", func(t *testing.T) {
+	t.Run("logs not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		for _, s := range result.Stale {
 			if s.Kind == StaleKindLog {
-				t.Error("expected no log stale entries when includeLogs=false")
+				t.Error("expected no log stale entries without --all flag")
 			}
 		}
 	})
@@ -245,7 +245,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, ".config"), 10)
 		createTestFile(t, filepath.Join(opentaintHome, ".last-update-check"), 10)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -267,7 +267,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.8.0.jar"), 100)
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.8.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -287,7 +287,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installLib := filepath.Join(home, ".opentaint", "install", "lib")
 		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -309,7 +309,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(false, true)
+		result, err := ScanForStaleArtifacts(true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -330,7 +330,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
 		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -347,7 +347,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
 		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false, true)
+		result, err := ScanForStaleArtifacts(true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -372,7 +372,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		modelsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
 		createTestFile(t, filepath.Join(modelsDir, "project-model", "project.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -394,7 +394,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		stagingDir := filepath.Join(modelsDir, ".staging-12345-9999")
 		createTestFile(t, filepath.Join(stagingDir, "project-model", "project.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -417,7 +417,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -432,13 +432,13 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 	setupPruneTestGlobals(t)
 
-	t.Run("logs inside project cache are prunable", func(t *testing.T) {
+	t.Run("logs inside project cache prunable with all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
 
-		result, err := ScanForStaleArtifacts(true, false)
+		result, err := ScanForStaleArtifacts(true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -449,23 +449,23 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Error("expected logs to be flagged as prunable")
+			t.Error("expected logs to be flagged as prunable with --all flag")
 		}
 	})
 
-	t.Run("logs not pruned when include-logs is false", func(t *testing.T) {
+	t.Run("logs not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
 
-		result, err := ScanForStaleArtifacts(false, false)
+		result, err := ScanForStaleArtifacts(false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		for _, s := range result.Stale {
 			if s.Kind == StaleKindLog {
-				t.Error("expected no log stale entries when include-logs is false")
+				t.Error("expected no log stale entries without --all flag")
 			}
 		}
 	})

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -37,6 +37,62 @@ func TestDeleteArtifacts(t *testing.T) {
 		}
 	})
 
+	t.Run("cleans up empty parent dirs for model artifacts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "cache")
+		projectDir := filepath.Join(cacheDir, "my-project-a1b2c3d4")
+		pmDir := filepath.Join(projectDir, "project-model")
+		createTestFile(t, filepath.Join(pmDir, "project.yaml"), 50)
+
+		artifacts := []StaleArtifact{
+			{Path: pmDir, Size: 50, Kind: StaleKindModel},
+		}
+
+		if err := DeleteArtifacts(artifacts); err != nil {
+			t.Fatalf("DeleteArtifacts() error = %v", err)
+		}
+
+		// project-model/ should be gone
+		if _, err := os.Stat(pmDir); !os.IsNotExist(err) {
+			t.Errorf("expected project-model dir to be removed")
+		}
+		// Empty project dir should be cleaned up
+		if _, err := os.Stat(projectDir); !os.IsNotExist(err) {
+			t.Errorf("expected empty project cache dir to be removed")
+		}
+		// Empty cache dir should be cleaned up
+		if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+			t.Errorf("expected empty cache dir to be removed")
+		}
+	})
+
+	t.Run("preserves non-empty parent dirs for model artifacts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "cache")
+		projectDir := filepath.Join(cacheDir, "my-project-a1b2c3d4")
+		pmDir := filepath.Join(projectDir, "project-model")
+		createTestFile(t, filepath.Join(pmDir, "project.yaml"), 50)
+		// Another project still exists in cache/
+		createTestFile(t, filepath.Join(cacheDir, "other-project-deadbeef", "project-model", "p.yaml"), 10)
+
+		artifacts := []StaleArtifact{
+			{Path: pmDir, Size: 50, Kind: StaleKindModel},
+		}
+
+		if err := DeleteArtifacts(artifacts); err != nil {
+			t.Fatalf("DeleteArtifacts() error = %v", err)
+		}
+
+		// Empty project dir should be cleaned up
+		if _, err := os.Stat(projectDir); !os.IsNotExist(err) {
+			t.Errorf("expected empty project cache dir to be removed")
+		}
+		// cache dir should remain (has other project)
+		if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+			t.Errorf("expected cache dir to remain (has other projects)")
+		}
+	})
+
 	t.Run("empty slice is no-op", func(t *testing.T) {
 		if err := DeleteArtifacts(nil); err != nil {
 			t.Fatalf("DeleteArtifacts(nil) error = %v", err)

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -87,7 +87,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 
 	t.Run("empty home", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -102,7 +102,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -120,7 +120,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_1.0.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -135,7 +135,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -154,7 +154,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
 		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -173,7 +173,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jdkDir := filepath.Join(opentaintHome, "jdk", "temurin-17-jdk+35")
 		createTestFile(t, filepath.Join(jdkDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -192,7 +192,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-17-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -211,7 +211,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-21-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -220,32 +220,17 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("logs included in model prune with all flag", func(t *testing.T) {
+
+	t.Run("logs dir skipped in home scan", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
+		logsDir := filepath.Join(home, ".opentaint", "logs", "my-project-a1b2c3d4")
 		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// With --all, entire project cache dir is pruned as model (includes logs)
-		assertHasKind(t, result, StaleKindModel)
-		assertNoKind(t, result, StaleKindLog)
-	})
-
-	t.Run("logs-only dir not pruned without all flag", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv("HOME", home)
-		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
-		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
-
-		result, err := ScanForStaleArtifacts(false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		assertNoKind(t, result, StaleKindModel)
 		assertNoKind(t, result, StaleKindLog)
 	})
 
@@ -256,7 +241,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, ".config"), 10)
 		createTestFile(t, filepath.Join(opentaintHome, ".last-update-check"), 10)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -278,7 +263,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.8.0.jar"), 100)
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.8.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -298,7 +283,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installLib := filepath.Join(home, ".opentaint", "install", "lib")
 		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -316,7 +301,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(PruneCategoriesAll)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -329,7 +314,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
 		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -342,7 +327,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
 		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(PruneCategoriesAll)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -360,7 +345,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		pmPath := filepath.Join(projectDir, "project-model", "project.yaml")
 		createTestFile(t, pmPath, 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -376,35 +361,16 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		}
 	})
 
-	t.Run("cached model with all prunes entire dir", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv("HOME", home)
-		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
-		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
-
-		result, err := ScanForStaleArtifacts(true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		assertHasKind(t, result, StaleKindModel)
-		// Should target the entire project cache dir
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindModel {
-				if s.Path != projectDir {
-					t.Errorf("expected path %q, got %q", projectDir, s.Path)
-				}
-			}
-		}
-	})
-
 	t.Run("logs preserved without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
 		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
-		createTestFile(t, filepath.Join(projectDir, "logs", "2026-01-01.log"), 100)
+		// Logs are now in ~/.opentaint/logs/, not in cache dirs
+		logsDir := filepath.Join(home, ".opentaint", "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -423,13 +389,15 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		t.Setenv("HOME", home)
 		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
 		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
-		createTestFile(t, filepath.Join(projectDir, "logs", "2026-01-01.log"), 100)
+		// Logs live in their own top-level directory, counted separately
+		logsDir := filepath.Join(home, ".opentaint", "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 100)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(PruneCategoriesAll)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// Should have exactly one entry for the entire dir, no separate log entry
+		// Model entry targets project-model/ subdir
 		modelCount := 0
 		for _, s := range result.Stale {
 			if s.Kind == StaleKindModel {
@@ -439,7 +407,16 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		if modelCount != 1 {
 			t.Errorf("expected 1 model entry, got %d", modelCount)
 		}
-		assertNoKind(t, result, StaleKindLog)
+		// Log entry is separate, targeting ~/.opentaint/logs/<slug>/
+		logCount := 0
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindLog {
+				logCount++
+			}
+		}
+		if logCount != 1 {
+			t.Errorf("expected 1 log entry, got %d", logCount)
+		}
 	})
 
 	t.Run("stale staging dir is prunable", func(t *testing.T) {
@@ -449,7 +426,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		stagingDir := filepath.Join(projectDir, ".staging-12345-9999")
 		createTestFile(t, filepath.Join(stagingDir, "project-model", "project.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -472,7 +449,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -480,36 +457,105 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 	})
 }
 
-func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
+func TestScanForStaleArtifacts_Categories(t *testing.T) {
 	setupPruneTestGlobals(t)
 
-	t.Run("logs-only cache dir pruned with all flag", func(t *testing.T) {
+	t.Run("artifacts-only prunes jars not rules", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
-		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
+		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(PruneCategoryArtifacts)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// With --all, the entire project cache dir is pruned (includes logs)
-		assertHasKind(t, result, StaleKindModel)
+		assertHasKind(t, result, StaleKindAnalyzer)
+		assertNoKind(t, result, StaleKindRules)
 	})
 
-	t.Run("logs-only cache dir not pruned without all flag", func(t *testing.T) {
+	t.Run("rules-only prunes rules not jars", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
-		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
-		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
+		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(PruneCategoryRules)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// Without --all, only project-model/ and .staging-* are pruned; logs are preserved
+		assertHasKind(t, result, StaleKindRules)
+		assertNoKind(t, result, StaleKindAnalyzer)
+	})
+
+	t.Run("logs-only scans logs dir", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		logsDir := filepath.Join(home, ".opentaint", "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 100)
+
+		result, err := ScanForStaleArtifacts(PruneCategoryLogs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindLog)
 		assertNoKind(t, result, StaleKindModel)
+		assertNoKind(t, result, StaleKindAnalyzer)
+	})
+
+	t.Run("default categories match expected behavior", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		// Artifact (should be pruned)
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		// Rules (should be pruned)
+		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
+		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
+		// JDK (should be pruned)
+		jdkDir := filepath.Join(opentaintHome, "jdk", "temurin-17-jdk+35")
+		createTestFile(t, filepath.Join(jdkDir, "bin", "java"), 50)
+		// Model (should be pruned)
+		pmPath := filepath.Join(opentaintHome, "cache", "my-project-a1b2c3d4", "project-model", "project.yaml")
+		createTestFile(t, pmPath, 50)
+		// Logs (should NOT be pruned with default)
+		logsDir := filepath.Join(opentaintHome, "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 100)
+		// Install (should NOT be pruned with default)
+		installLib := filepath.Join(opentaintHome, "install", "lib")
+		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
+
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindAnalyzer)
+		assertHasKind(t, result, StaleKindRules)
+		assertHasKind(t, result, StaleKindJDK)
+		assertHasKind(t, result, StaleKindModel)
 		assertNoKind(t, result, StaleKindLog)
+		assertNoKind(t, result, StaleKindInstallLib)
+	})
+
+	t.Run("all categories include logs and install", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		logsDir := filepath.Join(opentaintHome, "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 100)
+		installLib := filepath.Join(opentaintHome, "install", "lib")
+		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
+
+		result, err := ScanForStaleArtifacts(PruneCategoriesAll)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindLog)
+		assertHasKind(t, result, StaleKindInstallLib)
 	})
 }
 

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -62,6 +62,26 @@ func setupPruneTestGlobals(t *testing.T) {
 	globals.DefaultJavaVersion = 21
 }
 
+func assertHasKind(t *testing.T, result *PruneResult, kind string) {
+	t.Helper()
+	for _, s := range result.Stale {
+		if s.Kind == kind {
+			return
+		}
+	}
+	t.Errorf("expected stale entry with kind %q, found none", kind)
+}
+
+func assertNoKind(t *testing.T, result *PruneResult, kind string) {
+	t.Helper()
+	for _, s := range result.Stale {
+		if s.Kind == kind {
+			t.Errorf("expected no stale entry with kind %q, but found one at %s", kind, s.Path)
+			return
+		}
+	}
+}
+
 func TestScanForStaleArtifacts(t *testing.T) {
 	setupPruneTestGlobals(t)
 
@@ -210,15 +230,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindLog {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected log stale entry with --all flag")
-		}
+		assertHasKind(t, result, StaleKindLog)
 	})
 
 	t.Run("logs not pruned without all flag", func(t *testing.T) {
@@ -231,11 +243,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindLog {
-				t.Error("expected no log stale entries without --all flag")
-			}
-		}
+		assertNoKind(t, result, StaleKindLog)
 	})
 
 	t.Run("hidden files skipped", func(t *testing.T) {
@@ -291,11 +299,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindInstallLib {
-				t.Error("expected install-lib not to be flagged without --all flag")
-			}
-		}
+		assertNoKind(t, result, StaleKindInstallLib)
 	})
 
 	t.Run("current install-lib pruned with all flag", func(t *testing.T) {
@@ -313,15 +317,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindInstallLib {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected install-lib to be flagged with --all flag even when marker is current")
-		}
+		assertHasKind(t, result, StaleKindInstallLib)
 	})
 
 	t.Run("install-jre not pruned without all flag", func(t *testing.T) {
@@ -334,11 +330,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindInstallJRE {
-				t.Error("expected install-jre not to be flagged without --all flag")
-			}
-		}
+		assertNoKind(t, result, StaleKindInstallJRE)
 	})
 
 	t.Run("install-jre pruned with all flag", func(t *testing.T) {
@@ -351,15 +343,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindInstallJRE {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected install-jre to be flagged as stale with --all flag")
-		}
+		assertHasKind(t, result, StaleKindInstallJRE)
 	})
 }
 
@@ -376,15 +360,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindModel {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected cached model to be flagged as prunable")
-		}
+		assertHasKind(t, result, StaleKindModel)
 	})
 
 	t.Run("stale staging dir is prunable", func(t *testing.T) {
@@ -398,15 +374,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindModel {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected stale staging dir to be flagged as prunable")
-		}
+		assertHasKind(t, result, StaleKindModel)
 	})
 
 	t.Run("empty models dir produces no stale", func(t *testing.T) {
@@ -421,11 +389,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindModel {
-				t.Error("expected no model stale entries for empty models dir")
-			}
-		}
+		assertNoKind(t, result, StaleKindModel)
 	})
 }
 
@@ -442,15 +406,7 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindLog {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected logs to be flagged as prunable with --all flag")
-		}
+		assertHasKind(t, result, StaleKindLog)
 	})
 
 	t.Run("logs not pruned without all flag", func(t *testing.T) {
@@ -463,11 +419,7 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindLog {
-				t.Error("expected no log stale entries without --all flag")
-			}
-		}
+		assertNoKind(t, result, StaleKindLog)
 	})
 }
 

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -67,7 +67,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 
 	t.Run("empty home", func(t *testing.T) {
 		t.Setenv("HOME", t.TempDir())
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -82,7 +82,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -100,7 +100,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_1.0.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -115,7 +115,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		opentaintHome := filepath.Join(home, ".opentaint")
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.9.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		rulesDir := filepath.Join(opentaintHome, "rules_v0.9.0")
 		createTestFile(t, filepath.Join(rulesDir, "rule.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -153,7 +153,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jdkDir := filepath.Join(opentaintHome, "jdk", "temurin-17-jdk+35")
 		createTestFile(t, filepath.Join(jdkDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-17-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -191,7 +191,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		jreDir := filepath.Join(opentaintHome, "jre", "temurin-21-jre+35")
 		createTestFile(t, filepath.Join(jreDir, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(true, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -227,7 +227,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "app.log"), 200)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, ".config"), 10)
 		createTestFile(t, filepath.Join(opentaintHome, ".last-update-check"), 10)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -267,7 +267,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.8.0.jar"), 100)
 		createTestFile(t, filepath.Join(opentaintHome, "autobuilder_0.8.0.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -287,7 +287,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		installLib := filepath.Join(home, ".opentaint", "install", "lib")
 		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -313,7 +313,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -324,13 +324,56 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("stale install-jre no marker", func(t *testing.T) {
+	t.Run("current install-lib pruned with all flag", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		installLib := filepath.Join(home, ".opentaint", "install", "lib")
+		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
+
+		// Write current marker
+		if err := WriteInstallVersionMarker(); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := ScanForStaleArtifacts(false, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		found := false
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindInstallLib {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected install-lib to be flagged with --all flag even when marker is current")
+		}
+	})
+
+	t.Run("install-jre not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
 		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, s := range result.Stale {
+			if s.Kind == StaleKindInstallJRE {
+				t.Error("expected install-jre not to be flagged without --all flag")
+			}
+		}
+	})
+
+	t.Run("install-jre pruned with all flag", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		installJRE := filepath.Join(home, ".opentaint", "install", "jre")
+		createTestFile(t, filepath.Join(installJRE, "bin", "java"), 50)
+
+		result, err := ScanForStaleArtifacts(false, true)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -341,7 +384,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Error("expected install-jre to be flagged as stale when no version marker exists")
+			t.Error("expected install-jre to be flagged as stale with --all flag")
 		}
 	})
 }
@@ -355,7 +398,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		modelsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
 		createTestFile(t, filepath.Join(modelsDir, "project-model", "project.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -377,7 +420,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 		stagingDir := filepath.Join(modelsDir, ".staging-12345-9999")
 		createTestFile(t, filepath.Join(stagingDir, "project-model", "project.yaml"), 50)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -400,7 +443,7 @@ func TestScanForStaleArtifacts_CachedModels(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -421,7 +464,7 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
 
-		result, err := ScanForStaleArtifacts(true)
+		result, err := ScanForStaleArtifacts(true, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -442,7 +485,7 @@ func TestScanForStaleArtifacts_LogsInCacheDirs(t *testing.T) {
 		logsDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4", "logs")
 		createTestFile(t, filepath.Join(logsDir, "2026-01-01_00-00-00.log"), 100)
 
-		result, err := ScanForStaleArtifacts(false)
+		result, err := ScanForStaleArtifacts(false, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -559,6 +559,37 @@ func TestScanForStaleArtifacts_Categories(t *testing.T) {
 	})
 }
 
+func TestScanForStaleArtifacts_LockedModelSkipped(t *testing.T) {
+	setupPruneTestGlobals(t)
+
+	t.Run("locked project is skipped during model scan", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		projectDir := filepath.Join(home, ".opentaint", "cache", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(projectDir, "project-model", "project.yaml"), 50)
+
+		// Hold the compile lock
+		lockPath := CompileLockPath(projectDir)
+		lock, err := TryLock(lockPath, LockMeta{PID: 99999, Command: "compile"})
+		if err != nil {
+			t.Fatalf("failed to acquire compile lock: %v", err)
+		}
+		defer lock.Unlock()
+
+		result, err := ScanForStaleArtifacts(PruneCategoryModels)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertNoKind(t, result, StaleKindModel)
+		if len(result.Skipped) != 1 {
+			t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
+		}
+		if result.Skipped[0].Meta.PID != 99999 {
+			t.Errorf("expected PID 99999, got %d", result.Skipped[0].Meta.PID)
+		}
+	})
+}
+
 func TestPruneResult_AddSkipped(t *testing.T) {
 	result := &PruneResult{}
 	result.AddSkipped(SkippedProject{

--- a/cli/internal/utils/prune_test.go
+++ b/cli/internal/utils/prune_test.go
@@ -281,7 +281,7 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		}
 	})
 
-	t.Run("stale install-lib no marker", func(t *testing.T) {
+	t.Run("install-lib not pruned without all flag", func(t *testing.T) {
 		home := t.TempDir()
 		t.Setenv("HOME", home)
 		installLib := filepath.Join(home, ".opentaint", "install", "lib")
@@ -291,35 +291,9 @@ func TestScanForStaleArtifacts(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		found := false
 		for _, s := range result.Stale {
 			if s.Kind == StaleKindInstallLib {
-				found = true
-			}
-		}
-		if !found {
-			t.Error("expected install-lib to be flagged as stale when no version marker exists")
-		}
-	})
-
-	t.Run("current install-lib with marker", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv("HOME", home)
-		installLib := filepath.Join(home, ".opentaint", "install", "lib")
-		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
-
-		// Write current marker
-		if err := WriteInstallVersionMarker(); err != nil {
-			t.Fatal(err)
-		}
-
-		result, err := ScanForStaleArtifacts(false, false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		for _, s := range result.Stale {
-			if s.Kind == StaleKindInstallLib {
-				t.Error("expected install-lib not to be flagged when version marker is current")
+				t.Error("expected install-lib not to be flagged without --all flag")
 			}
 		}
 	})

--- a/cli/internal/utils/tier.go
+++ b/cli/internal/utils/tier.go
@@ -89,7 +89,7 @@ func ArtifactTiers(def globals.ArtifactDef) ([]Tier, error) {
 			tiers = append(tiers, Tier{TierInstall, filepath.Join(libPath, def.LibSubpath)})
 		}
 	} else {
-		opentaintHome, err := GetOpentaintHome()
+		opentaintHome, err := GetOpenTaintHome()
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/utils/updater.go
+++ b/cli/internal/utils/updater.go
@@ -189,23 +189,23 @@ func SelfUpdate(archivePath, installDir string) error {
 	// Preserve the installation style: if bundled artifacts exist next to the
 	// binary, update them in place. Otherwise, place into the install tier
 	// (~/.opentaint/install/) so bare-binary installations stay bare.
-	bundledLib := filepath.Join(installDir, "lib")
-	bundledJRE := filepath.Join(installDir, "jre")
+	libBundled := pathExists(filepath.Join(installDir, "lib"))
+	jreBundled := pathExists(filepath.Join(installDir, "jre"))
 
-	_, libBundled := os.Stat(bundledLib)
-	_, jreBundled := os.Stat(bundledJRE)
-
-	if err := updateArtifactDir(tmpDir, "lib", libBundled == nil, installDir); err != nil {
+	if err := updateArtifactDir(tmpDir, "lib", libBundled, installDir); err != nil {
 		output.LogInfof("Failed to update lib directory: %v", err)
 	}
-	if err := updateArtifactDir(tmpDir, "jre", jreBundled == nil, installDir); err != nil {
+	if err := updateArtifactDir(tmpDir, "jre", jreBundled, installDir); err != nil {
 		output.LogInfof("Failed to update jre directory: %v", err)
 	}
 
-	// If anything was placed in the install tier, update the version marker.
-	if libBundled != nil || jreBundled != nil {
-		if err := WriteInstallVersionMarker(); err != nil {
-			output.LogInfof("Failed to write install version marker: %v", err)
+	// Remove stale install-tier marker so the next run reconciles it.
+	// We cannot write the correct marker here because the running binary
+	// still has the OLD embedded versions.yaml. ReconcileInstallMarker
+	// (called from PersistentPreRunE) handles it on the new binary's first run.
+	if !libBundled || !jreBundled {
+		if dir := GetInstallDir(); dir != "" {
+			_ = os.Remove(filepath.Join(dir, ".versions"))
 		}
 	}
 
@@ -214,8 +214,8 @@ func SelfUpdate(archivePath, installDir string) error {
 
 // updateArtifactDir moves an extracted artifact directory (lib or jre) to the
 // appropriate location. When bundled is true, it replaces the directory next to
-// the binary (installDir). Otherwise it places it in the install tier.
-func updateArtifactDir(tmpDir, name string, bundled bool, installDir string) error {
+// the binary (exeDir). Otherwise it places it in the install tier.
+func updateArtifactDir(tmpDir, name string, bundled bool, exeDir string) error {
 	src := filepath.Join(tmpDir, name)
 	if _, err := os.Stat(src); err != nil {
 		return nil // archive doesn't contain this directory
@@ -223,7 +223,7 @@ func updateArtifactDir(tmpDir, name string, bundled bool, installDir string) err
 
 	var dest string
 	if bundled {
-		dest = filepath.Join(installDir, name)
+		dest = filepath.Join(exeDir, name)
 	} else {
 		dir := GetInstallDir()
 		if dir == "" {

--- a/cli/internal/utils/updater.go
+++ b/cli/internal/utils/updater.go
@@ -185,27 +185,58 @@ func SelfUpdate(archivePath, installDir string) error {
 		}
 	}
 
-	// Update lib/ directory
-	newLib := filepath.Join(tmpDir, "lib")
-	if _, err := os.Stat(newLib); err == nil {
-		currentLib := filepath.Join(installDir, "lib")
-		_ = os.RemoveAll(currentLib)
-		if err := os.Rename(newLib, currentLib); err != nil {
-			output.LogInfof("Failed to update lib directory: %v", err)
-		}
+	// Update lib/ and jre/ directories.
+	// Preserve the installation style: if bundled artifacts exist next to the
+	// binary, update them in place. Otherwise, place into the install tier
+	// (~/.opentaint/install/) so bare-binary installations stay bare.
+	bundledLib := filepath.Join(installDir, "lib")
+	bundledJRE := filepath.Join(installDir, "jre")
+
+	_, libBundled := os.Stat(bundledLib)
+	_, jreBundled := os.Stat(bundledJRE)
+
+	if err := updateArtifactDir(tmpDir, "lib", libBundled == nil, installDir); err != nil {
+		output.LogInfof("Failed to update lib directory: %v", err)
+	}
+	if err := updateArtifactDir(tmpDir, "jre", jreBundled == nil, installDir); err != nil {
+		output.LogInfof("Failed to update jre directory: %v", err)
 	}
 
-	// Update jre/ directory
-	newJRE := filepath.Join(tmpDir, "jre")
-	if _, err := os.Stat(newJRE); err == nil {
-		currentJRE := filepath.Join(installDir, "jre")
-		_ = os.RemoveAll(currentJRE)
-		if err := os.Rename(newJRE, currentJRE); err != nil {
-			output.LogInfof("Failed to update jre directory: %v", err)
+	// If anything was placed in the install tier, update the version marker.
+	if libBundled != nil || jreBundled != nil {
+		if err := WriteInstallVersionMarker(); err != nil {
+			output.LogInfof("Failed to write install version marker: %v", err)
 		}
 	}
 
 	return nil
+}
+
+// updateArtifactDir moves an extracted artifact directory (lib or jre) to the
+// appropriate location. When bundled is true, it replaces the directory next to
+// the binary (installDir). Otherwise it places it in the install tier.
+func updateArtifactDir(tmpDir, name string, bundled bool, installDir string) error {
+	src := filepath.Join(tmpDir, name)
+	if _, err := os.Stat(src); err != nil {
+		return nil // archive doesn't contain this directory
+	}
+
+	var dest string
+	if bundled {
+		dest = filepath.Join(installDir, name)
+	} else {
+		dir := GetInstallDir()
+		if dir == "" {
+			return nil
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create install dir: %w", err)
+		}
+		dest = filepath.Join(dir, name)
+	}
+
+	_ = os.RemoveAll(dest)
+	return os.Rename(src, dest)
 }
 
 // extractTarGzFile extracts a .tar.gz file to a destination directory.

--- a/cli/internal/utils/updater_test.go
+++ b/cli/internal/utils/updater_test.go
@@ -146,10 +146,18 @@ func TestSelfUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create install directory with an existing binary
+	// Create install directory with an existing binary and bundled artifact dirs
+	// so that SelfUpdate recognises this as a bundled installation and updates
+	// lib/ and jre/ in-place rather than placing them in the install tier.
 	installDir := t.TempDir()
 	existingBinary := filepath.Join(installDir, "opentaint")
 	if err := os.WriteFile(existingBinary, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(installDir, "lib"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(installDir, "jre"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/docs/superpowers/plans/2026-04-16-prune-lockfiles-granular-flags.md
+++ b/docs/superpowers/plans/2026-04-16-prune-lockfiles-granular-flags.md
@@ -1,0 +1,1304 @@
+# Prune: Lockfiles & Granular Flags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add cross-platform file locking and granular category flags to the `opentaint prune` command, and move logs to a separate top-level directory.
+
+**Architecture:** Introduce a `lock.go` module wrapping `github.com/gofrs/flock` for cross-platform advisory file locks. Refactor `ScanForStaleArtifacts` to accept a category set instead of a single `all` bool. Move log writing from `cache/<slug>/logs/` to `logs/<slug>/`. Replace `HasStagingDir` heuristic with flock-based compile locks.
+
+**Tech Stack:** Go 1.25, `github.com/gofrs/flock`, Cobra CLI framework
+
+**Spec:** `docs/superpowers/specs/2026-04-16-prune-lockfiles-granular-flags-design.md`
+
+---
+
+### Task 1: Add `github.com/gofrs/flock` dependency
+
+**Files:**
+- Modify: `cli/go.mod`
+- Modify: `cli/go.sum`
+
+- [ ] **Step 1: Add the dependency**
+
+```bash
+cd cli && go get github.com/gofrs/flock
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd cli && go build ./...
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cli/go.mod cli/go.sum
+git commit -m "chore: add github.com/gofrs/flock dependency"
+```
+
+---
+
+### Task 2: Implement `lock.go` — cross-platform file locking
+
+**Files:**
+- Create: `cli/internal/utils/lock.go`
+- Create: `cli/internal/utils/lock_test.go`
+
+- [ ] **Step 1: Write failing tests for lock acquisition**
+
+Create `cli/internal/utils/lock_test.go` with tests:
+
+```go
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTryLock(t *testing.T) {
+	t.Run("acquires lock on new file", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "test"})
+		if err != nil {
+			t.Fatalf("TryLock() error = %v", err)
+		}
+		defer lock.Unlock()
+	})
+
+	t.Run("second lock on same file returns ErrLocked", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock1, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "first"})
+		if err != nil {
+			t.Fatalf("first TryLock() error = %v", err)
+		}
+		defer lock1.Unlock()
+
+		_, err = TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "second"})
+		if err != ErrLocked {
+			t.Fatalf("expected ErrLocked, got %v", err)
+		}
+	})
+
+	t.Run("lock released after Unlock allows re-acquisition", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		lock1, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "first"})
+		if err != nil {
+			t.Fatalf("first TryLock() error = %v", err)
+		}
+		lock1.Unlock()
+
+		lock2, err := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "second"})
+		if err != nil {
+			t.Fatalf("second TryLock() error = %v", err)
+		}
+		defer lock2.Unlock()
+	})
+}
+
+func TestReadLockMeta(t *testing.T) {
+	t.Run("reads PID and command from lock file", func(t *testing.T) {
+		lockPath := filepath.Join(t.TempDir(), "test.lock")
+		meta := LockMeta{PID: 12345, Command: "compile", Project: "/tmp/my-project"}
+		lock, err := TryLock(lockPath, meta)
+		if err != nil {
+			t.Fatalf("TryLock() error = %v", err)
+		}
+		defer lock.Unlock()
+
+		got, err := ReadLockMeta(lockPath)
+		if err != nil {
+			t.Fatalf("ReadLockMeta() error = %v", err)
+		}
+		if got.PID != 12345 {
+			t.Errorf("PID = %d, want 12345", got.PID)
+		}
+		if got.Command != "compile" {
+			t.Errorf("Command = %q, want %q", got.Command, "compile")
+		}
+		if got.Project != "/tmp/my-project" {
+			t.Errorf("Project = %q, want %q", got.Project, "/tmp/my-project")
+		}
+	})
+
+	t.Run("returns error for missing file", func(t *testing.T) {
+		_, err := ReadLockMeta(filepath.Join(t.TempDir(), "missing.lock"))
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestTryLock|TestReadLockMeta" -v
+```
+Expected: FAIL — `TryLock`, `LockMeta`, `ErrLocked`, `ReadLockMeta` undefined
+
+- [ ] **Step 3: Implement `lock.go`**
+
+Create `cli/internal/utils/lock.go`:
+
+```go
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gofrs/flock"
+)
+
+// ErrLocked is returned when a lock file is already held by another process.
+var ErrLocked = errors.New("lock is held by another process")
+
+// LockMeta holds diagnostic information written into lock files.
+type LockMeta struct {
+	PID     int
+	Command string
+	Project string
+}
+
+// FileLock wraps a flock.Flock with its path for cleanup.
+type FileLock struct {
+	flock *flock.Flock
+	path  string
+}
+
+// Unlock releases the advisory lock and removes the lock file.
+func (l *FileLock) Unlock() {
+	_ = l.flock.Unlock()
+	_ = os.Remove(l.path)
+}
+
+// TryLock attempts a non-blocking exclusive lock on the given path.
+// On success it writes meta into the file and returns a FileLock.
+// On failure because the lock is held, it returns ErrLocked.
+func TryLock(lockPath string, meta LockMeta) (*FileLock, error) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create lock directory: %w", err)
+	}
+
+	fl := flock.New(lockPath)
+	locked, err := fl.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire lock: %w", err)
+	}
+	if !locked {
+		return nil, ErrLocked
+	}
+
+	content := fmt.Sprintf("pid=%d\ncommand=%s\n", meta.PID, meta.Command)
+	if meta.Project != "" {
+		content += fmt.Sprintf("project=%s\n", meta.Project)
+	}
+	_ = os.WriteFile(lockPath, []byte(content), 0o644)
+
+	return &FileLock{flock: fl, path: lockPath}, nil
+}
+
+// ReadLockMeta reads diagnostic metadata from a lock file.
+func ReadLockMeta(lockPath string) (LockMeta, error) {
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return LockMeta{}, err
+	}
+	var meta LockMeta
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "pid":
+			meta.PID, _ = strconv.Atoi(value)
+		case "command":
+			meta.Command = value
+		case "project":
+			meta.Project = value
+		}
+	}
+	return meta, nil
+}
+
+// PruneLockPath returns the path to the global prune lock: ~/.opentaint/.prune.lock
+func PruneLockPath() (string, error) {
+	home, err := GetOpenTaintHomePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".prune.lock"), nil
+}
+
+// CompileLockPath returns the path to a per-project compile lock:
+// ~/.opentaint/cache/<slug-hash>/.compile.lock
+func CompileLockPath(projectCachePath string) string {
+	return filepath.Join(projectCachePath, ".compile.lock")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestTryLock|TestReadLockMeta" -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/internal/utils/lock.go cli/internal/utils/lock_test.go
+git commit -m "feat: add cross-platform file locking with gofrs/flock"
+```
+
+---
+
+### Task 3: Move log writing to `~/.opentaint/logs/<slug-hash>/`
+
+**Files:**
+- Modify: `cli/internal/utils/log/project_log.go`
+- Modify: `cli/internal/utils/model_cache.go` (add `GetLogCacheDirPath` / `GetProjectLogPath`)
+- Modify: `cli/cmd/logging.go` (use new log path)
+- Modify: `cli/cmd/scan.go` (pass log path instead of cache path)
+
+- [ ] **Step 1: Write failing test for new log path helper**
+
+Add to `cli/internal/utils/model_cache_test.go` (or create it):
+
+```go
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetProjectLogPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	projectPath := "/Users/dev/my-project"
+	logPath, err := GetProjectLogPath(projectPath)
+	if err != nil {
+		t.Fatalf("GetProjectLogPath() error = %v", err)
+	}
+
+	slugHash := ProjectPathSlugHash(projectPath)
+	expected := filepath.Join(home, ".opentaint", "logs", slugHash)
+	if logPath != expected {
+		t.Errorf("got %q, want %q", logPath, expected)
+	}
+}
+
+func TestGetLogCacheDirPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	logDir, err := GetLogCacheDirPath()
+	if err != nil {
+		t.Fatalf("GetLogCacheDirPath() error = %v", err)
+	}
+	expected := filepath.Join(home, ".opentaint", "logs")
+	if logDir != expected {
+		t.Errorf("got %q, want %q", logDir, expected)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestGetProjectLogPath|TestGetLogCacheDirPath" -v
+```
+Expected: FAIL — undefined functions
+
+- [ ] **Step 3: Add log path helpers to `model_cache.go`**
+
+Add to `cli/internal/utils/model_cache.go`:
+
+```go
+const logsCacheDir = "logs"
+
+// GetLogCacheDirPath returns ~/.opentaint/logs/ without creating it.
+func GetLogCacheDirPath() (string, error) {
+	opentaintHome, err := GetOpenTaintHomePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(opentaintHome, logsCacheDir), nil
+}
+
+// GetProjectLogPath returns ~/.opentaint/logs/<slug-hash>/ for a project path,
+// without creating the directory. The project path is canonicalized before hashing.
+func GetProjectLogPath(projectPath string) (string, error) {
+	absPath, err := filepath.Abs(projectPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	logsDir, err := GetLogCacheDirPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(logsDir, ProjectPathSlugHash(absPath)), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestGetProjectLogPath|TestGetLogCacheDirPath" -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Update `project_log.go` to accept any directory**
+
+Modify `cli/internal/utils/log/project_log.go` — the function already takes a `cacheDir` parameter, so the caller just needs to pass the new logs dir. No change needed to `project_log.go` itself.
+
+- [ ] **Step 6: Update `logging.go` to use the new log directory**
+
+Modify `cli/cmd/logging.go`. Change `activateLogging` to accept a `logDir` parameter (the `logs/<slug>` path) instead of `projectCachePath`:
+
+```go
+func activateLogging(logFilePath string, logDir string) {
+	var logPath string
+	var err error
+
+	if logFilePath != "" {
+		logPath = log.AbsPathOrExit(logFilePath, "log file")
+		if _, err = log.OpenLogFileAt(logPath); err != nil {
+			out.Fatalf("Failed to open log file: %s", err)
+		}
+	} else if logDir != "" {
+		logPath, err = log.OpenProjectLog(logDir)
+		if err != nil {
+			out.Fatalf("Failed to open project log file: %s", err)
+		}
+	}
+
+	if logPath != "" {
+		globals.LogPath = logPath
+		out.SetLogWriter(log.LogWriter())
+	}
+}
+
+func activateLoggingForProject(logFilePath string, projectPath string) {
+	logPath, err := utils.GetProjectLogPath(projectPath)
+	if err != nil {
+		output.LogInfof("Failed to resolve project log path: %v", err)
+	}
+	activateLogging(logFilePath, logPath)
+}
+```
+
+- [ ] **Step 7: Update `scan.go` to pass log path**
+
+In `cli/cmd/scan.go`, in function `scan()` around line 164-169, change the logging block:
+
+Replace:
+```go
+if !DryRunScan {
+	if cfg.projectCachePath != "" {
+		activateLogging(ScanLogFile, cfg.projectCachePath)
+	} else {
+		activateLoggingForProject(ScanLogFile, absUserProjectRoot)
+	}
+}
+```
+
+With:
+```go
+if !DryRunScan {
+	activateLoggingForProject(ScanLogFile, absUserProjectRoot)
+}
+```
+
+The `activateLoggingForProject` function now resolves the log path via `GetProjectLogPath` which uses `logs/<slug-hash>/`, so the `projectCachePath` branch is no longer needed.
+
+- [ ] **Step 8: Verify everything compiles and existing tests pass**
+
+```bash
+cd cli && go build ./... && go test ./...
+```
+Expected: all pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cli/internal/utils/model_cache.go cli/internal/utils/model_cache_test.go cli/cmd/logging.go cli/cmd/scan.go cli/internal/utils/log/project_log.go
+git commit -m "refactor: move project logs to ~/.opentaint/logs/<slug-hash>/"
+```
+
+---
+
+### Task 4: Introduce `PruneCategories` and refactor `ScanForStaleArtifacts`
+
+**Files:**
+- Modify: `cli/internal/utils/prune.go`
+- Modify: `cli/internal/utils/prune_test.go`
+
+- [ ] **Step 1: Define `PruneCategories` type and constants**
+
+Add to the top of `cli/internal/utils/prune.go`, replacing the existing `ScanForStaleArtifacts` signature. First, add the categories type:
+
+```go
+// PruneCategory represents a class of artifacts that can be selectively pruned.
+type PruneCategory int
+
+const (
+	PruneCategoryArtifacts PruneCategory = 1 << iota
+	PruneCategoryRules
+	PruneCategoryJDK
+	PruneCategoryModels
+	PruneCategoryLogs
+	PruneCategoryInstall
+)
+
+// PruneCategoriesDefault is the set pruned with no flags: artifacts + rules + jdk + models.
+const PruneCategoriesDefault = PruneCategoryArtifacts | PruneCategoryRules | PruneCategoryJDK | PruneCategoryModels
+
+// PruneCategoriesAll is the set pruned with --all.
+const PruneCategoriesAll = PruneCategoryArtifacts | PruneCategoryRules | PruneCategoryJDK | PruneCategoryModels | PruneCategoryLogs | PruneCategoryInstall
+```
+
+- [ ] **Step 2: Write failing tests for category-based scanning**
+
+Add new tests to `cli/internal/utils/prune_test.go`:
+
+```go
+func TestScanForStaleArtifacts_Categories(t *testing.T) {
+	setupPruneTestGlobals(t)
+
+	t.Run("artifacts-only prunes jars not rules", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		createTestFile(t, filepath.Join(opentaintHome, "rules_v0.9.0", "rule.yaml"), 50)
+
+		result, err := ScanForStaleArtifacts(PruneCategoryArtifacts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindAnalyzer)
+		assertNoKind(t, result, StaleKindRules)
+	})
+
+	t.Run("rules-only prunes rules not jars", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		createTestFile(t, filepath.Join(opentaintHome, "rules_v0.9.0", "rule.yaml"), 50)
+
+		result, err := ScanForStaleArtifacts(PruneCategoryRules)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertNoKind(t, result, StaleKindAnalyzer)
+		assertHasKind(t, result, StaleKindRules)
+	})
+
+	t.Run("logs-only scans logs dir", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		logsDir := filepath.Join(home, ".opentaint", "logs", "my-project-a1b2c3d4")
+		createTestFile(t, filepath.Join(logsDir, "2026-01-01.log"), 200)
+
+		result, err := ScanForStaleArtifacts(PruneCategoryLogs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindLog)
+	})
+
+	t.Run("default categories match old false behavior", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		createTestFile(t, filepath.Join(opentaintHome, "rules_v0.9.0", "rule.yaml"), 50)
+		jdkDir := filepath.Join(opentaintHome, "jdk", "temurin-17-jdk+35")
+		createTestFile(t, filepath.Join(jdkDir, "bin", "java"), 50)
+		pmPath := filepath.Join(opentaintHome, "cache", "proj-abc12345", "project-model", "project.yaml")
+		createTestFile(t, pmPath, 50)
+		logsDir := filepath.Join(opentaintHome, "logs", "proj-abc12345")
+		createTestFile(t, filepath.Join(logsDir, "app.log"), 100)
+
+		result, err := ScanForStaleArtifacts(PruneCategoriesDefault)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindAnalyzer)
+		assertHasKind(t, result, StaleKindRules)
+		assertHasKind(t, result, StaleKindJDK)
+		assertHasKind(t, result, StaleKindModel)
+		assertNoKind(t, result, StaleKindLog)
+		assertNoKind(t, result, StaleKindInstallLib)
+	})
+
+	t.Run("all categories include logs and install", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		opentaintHome := filepath.Join(home, ".opentaint")
+		createTestFile(t, filepath.Join(opentaintHome, "analyzer_0.9.0.jar"), 100)
+		installLib := filepath.Join(opentaintHome, "install", "lib")
+		createTestFile(t, filepath.Join(installLib, "artifact.jar"), 100)
+		logsDir := filepath.Join(opentaintHome, "logs", "proj-abc12345")
+		createTestFile(t, filepath.Join(logsDir, "app.log"), 100)
+
+		result, err := ScanForStaleArtifacts(PruneCategoriesAll)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assertHasKind(t, result, StaleKindAnalyzer)
+		assertHasKind(t, result, StaleKindLog)
+		assertHasKind(t, result, StaleKindInstallLib)
+	})
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestScanForStaleArtifacts_Categories" -v
+```
+Expected: FAIL — `ScanForStaleArtifacts` signature mismatch (expects `bool`, now called with `PruneCategory`)
+
+- [ ] **Step 4: Refactor `ScanForStaleArtifacts` to accept `PruneCategory`**
+
+Rewrite `cli/internal/utils/prune.go`. The `ScanForStaleArtifacts` function changes its parameter from `all bool` to `categories PruneCategory`. Key changes:
+
+```go
+// has reports whether the given category is included in the set.
+func (c PruneCategory) has(cat PruneCategory) bool {
+	return c&cat != 0
+}
+
+func ScanForStaleArtifacts(categories PruneCategory) (*PruneResult, error) {
+	opentaintHome, err := GetOpenTaintHomePath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get opentaint home: %w", err)
+	}
+
+	result := &PruneResult{}
+
+	entries, err := os.ReadDir(opentaintHome)
+	if os.IsNotExist(err) {
+		return result, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read opentaint home: %w", err)
+	}
+
+	if categories.has(PruneCategoryArtifacts) || categories.has(PruneCategoryRules) {
+		artifacts := globals.Artifacts()
+		for _, entry := range entries {
+			name := entry.Name()
+			fullPath := filepath.Join(opentaintHome, name)
+
+			if name == "cache" || name == "logs" || name == "install" || strings.HasPrefix(name, ".") {
+				continue
+			}
+
+			for _, def := range artifacts {
+				isArtifact := def.Kind() == "rules"
+				wantCategory := PruneCategoryRules
+				if !isArtifact {
+					wantCategory = PruneCategoryArtifacts
+				}
+				if !categories.has(wantCategory) {
+					if strings.HasPrefix(name, def.CachePrefix) {
+						break
+					}
+					continue
+				}
+				if artifact := checkStale(def, name, fullPath); artifact != nil {
+					result.Add(*artifact)
+					break
+				}
+				if strings.HasPrefix(name, def.CachePrefix) {
+					break
+				}
+			}
+		}
+	}
+
+	// JDK/JRE
+	if categories.has(PruneCategoryJDK) {
+		for _, kind := range []string{StaleKindJDK, StaleKindJRE} {
+			javaDir := filepath.Join(opentaintHome, kind)
+			subEntries, err := os.ReadDir(javaDir)
+			if err != nil {
+				continue
+			}
+			currentPrefix := fmt.Sprintf("temurin-%d-", globals.DefaultJavaVersion)
+			for _, subEntry := range subEntries {
+				if strings.HasPrefix(subEntry.Name(), currentPrefix) {
+					continue
+				}
+				subPath := filepath.Join(javaDir, subEntry.Name())
+				size, _ := dirSize(subPath)
+				result.Add(StaleArtifact{Path: subPath, Size: size, Kind: kind})
+			}
+		}
+	}
+
+	// Install-tier
+	if categories.has(PruneCategoryInstall) {
+		for _, check := range []struct {
+			path string
+			kind string
+		}{
+			{GetInstallLibPath(), StaleKindInstallLib},
+			{GetInstallJREPath(), StaleKindInstallJRE},
+		} {
+			if check.path == "" {
+				continue
+			}
+			if _, err := os.Stat(check.path); err != nil {
+				continue
+			}
+			size, _ := dirSize(check.path)
+			result.Add(StaleArtifact{Path: check.path, Size: size, Kind: check.kind})
+		}
+	}
+
+	// Models (cache dir)
+	if categories.has(PruneCategoryModels) {
+		modelsDir, mErr := GetModelCacheDirPath()
+		if mErr != nil {
+			output.LogDebugf("Failed to resolve model cache path: %v", mErr)
+		}
+		if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
+			modelEntries, err := os.ReadDir(modelsDir)
+			if err == nil {
+				for _, modelEntry := range modelEntries {
+					if !modelEntry.IsDir() {
+						continue
+					}
+					projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
+					scanProjectCacheSubdirs(projectCachePath, result)
+				}
+			}
+		}
+	}
+
+	// Logs (separate logs dir)
+	if categories.has(PruneCategoryLogs) {
+		logsDir, lErr := GetLogCacheDirPath()
+		if lErr != nil {
+			output.LogDebugf("Failed to resolve log cache path: %v", lErr)
+		}
+		if info, err := os.Stat(logsDir); err == nil && info.IsDir() {
+			logEntries, err := os.ReadDir(logsDir)
+			if err == nil {
+				for _, logEntry := range logEntries {
+					if !logEntry.IsDir() {
+						continue
+					}
+					logProjectDir := filepath.Join(logsDir, logEntry.Name())
+					size, _ := dirSize(logProjectDir)
+					if size > 0 {
+						result.Add(StaleArtifact{Path: logProjectDir, Size: size, Kind: StaleKindLog})
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+```
+
+Note: The `scanProjectCacheSubdirs` function remains for non-`--all` model scanning. With the categories approach, `--all` maps to `PruneCategoriesAll` which includes `PruneCategoryModels` — but models now always prune just `project-model/` and `.staging-*` (the old `--all` behavior of pruning entire cache dirs is replaced by `--models` + `--logs` together covering the same ground, since logs are now in a separate dir).
+
+- [ ] **Step 5: Update existing tests to use new signature**
+
+In `cli/internal/utils/prune_test.go`, update all calls to `ScanForStaleArtifacts`:
+
+- `ScanForStaleArtifacts(false)` → `ScanForStaleArtifacts(PruneCategoriesDefault)`
+- `ScanForStaleArtifacts(true)` → `ScanForStaleArtifacts(PruneCategoriesAll)`
+
+Tests related to "logs in cache dirs" can be updated or removed since logs now live in `logs/` not `cache/`. The `TestScanForStaleArtifacts_LogsInCacheDirs` tests should be replaced with tests for the new `logs/` directory scanning.
+
+Update `TestScanForStaleArtifacts_CachedModels`:
+- Remove the "cached model with all prunes entire dir" test — models now always target `project-model/` specifically
+- Update "no size double-counting" test — logs are in a separate dir now, so the test creates files in `logs/` instead of `cache/<slug>/logs/`
+- The "logs preserved without all flag" test becomes: logs are in `logs/` dir, `PruneCategoriesDefault` doesn't include `PruneCategoryLogs`
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+cd cli && go test ./internal/utils/ -v
+```
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/internal/utils/prune.go cli/internal/utils/prune_test.go
+git commit -m "refactor: replace bool flag with PruneCategory bitmask in ScanForStaleArtifacts"
+```
+
+---
+
+### Task 5: Add granular flags to the prune command
+
+**Files:**
+- Modify: `cli/cmd/prune.go`
+
+- [ ] **Step 1: Update `prune.go` with new flags and category resolution**
+
+Rewrite `cli/cmd/prune.go`:
+
+```go
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/seqra/opentaint/internal/output"
+	"github.com/seqra/opentaint/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pruneDryRun    bool
+	pruneYes       bool
+	pruneAll       bool
+	pruneArtifacts bool
+	pruneRules     bool
+	pruneJDK       bool
+	pruneModels    bool
+	pruneLogs      bool
+	pruneInstall   bool
+)
+
+// resolveCategories maps CLI flags to a PruneCategory bitmask.
+// Returns an error if --all is combined with specific flags.
+func resolveCategories() (utils.PruneCategory, error) {
+	specific := pruneArtifacts || pruneRules || pruneJDK || pruneModels || pruneLogs || pruneInstall
+	if pruneAll && specific {
+		return 0, fmt.Errorf("--all cannot be combined with specific category flags (--artifacts, --rules, --jdk, --models, --logs, --install)")
+	}
+	if pruneAll {
+		return utils.PruneCategoriesAll, nil
+	}
+	if !specific {
+		return utils.PruneCategoriesDefault, nil
+	}
+
+	var cats utils.PruneCategory
+	if pruneArtifacts {
+		cats |= utils.PruneCategoryArtifacts
+	}
+	if pruneRules {
+		cats |= utils.PruneCategoryRules
+	}
+	if pruneJDK {
+		cats |= utils.PruneCategoryJDK
+	}
+	if pruneModels {
+		cats |= utils.PruneCategoryModels
+	}
+	if pruneLogs {
+		cats |= utils.PruneCategoryLogs
+	}
+	if pruneInstall {
+		cats |= utils.PruneCategoryInstall
+	}
+	return cats, nil
+}
+
+var pruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove stale downloaded artifacts from ~/.opentaint",
+	Long: `Remove stale downloaded artifacts from the local cache (~/.opentaint).
+
+Identifies artifacts that are no longer needed:
+- Old versions of analyzer JARs, autobuilder JARs, and rules
+- Downloaded JDK/JRE versions that don't match the current version
+- Cached project models and staging directories
+
+Use category flags to prune selectively:
+  --artifacts   Stale analyzer and autobuilder JARs
+  --rules       Stale rules directories
+  --jdk         Old JDK/JRE versions
+  --models      Cached project models and staging directories
+  --logs        Project log files
+  --install     Install-tier lib and JRE artifacts
+
+Without category flags, prunes: artifacts + rules + jdk + models.
+With --all: prunes everything including logs and install-tier.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		categories, err := resolveCategories()
+		if err != nil {
+			out.FatalErr(err)
+		}
+
+		result, err := utils.ScanForStaleArtifacts(categories)
+		if err != nil {
+			out.Fatalf("Failed to scan for stale artifacts: %s", err)
+		}
+
+		if result.TotalCount == 0 {
+			out.Print("No stale artifacts found. Nothing to prune.")
+			return
+		}
+
+		sb := out.Section("Stale Artifacts")
+		for _, artifact := range result.Stale {
+			sb.Text(fmt.Sprintf("%s (%s) - %s", artifact.Path, artifact.Kind, output.FormatSize(artifact.Size)))
+		}
+		sb.Line().
+			Text(fmt.Sprintf("Total: %d items, %s", result.TotalCount, output.FormatSize(result.TotalSize))).
+			Render()
+
+		if pruneDryRun {
+			out.Print("Dry run mode. No files were deleted.")
+			return
+		}
+
+		if !pruneYes {
+			if !out.Confirm("Delete these artifacts?", false) {
+				out.Print("Prune cancelled.")
+				return
+			}
+		}
+
+		if err := utils.DeleteArtifacts(result.Stale); err != nil {
+			out.Fatalf("Failed to delete artifacts: %s", err)
+		}
+
+		out.Successf("Pruned %d items, freed %s", result.TotalCount, output.FormatSize(result.TotalSize))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pruneCmd)
+
+	pruneCmd.Flags().BoolVar(&pruneDryRun, "dry-run", false, "Show what would be deleted without deleting")
+	pruneCmd.Flags().BoolVar(&pruneYes, "yes", false, "Skip interactive confirmation")
+	pruneCmd.Flags().BoolVar(&pruneAll, "all", false, "Prune everything including logs and install-tier artifacts")
+	pruneCmd.Flags().BoolVar(&pruneArtifacts, "artifacts", false, "Prune stale analyzer and autobuilder JARs")
+	pruneCmd.Flags().BoolVar(&pruneRules, "rules", false, "Prune stale rules directories")
+	pruneCmd.Flags().BoolVar(&pruneJDK, "jdk", false, "Prune old JDK/JRE versions")
+	pruneCmd.Flags().BoolVar(&pruneModels, "models", false, "Prune cached project models and staging directories")
+	pruneCmd.Flags().BoolVar(&pruneLogs, "logs", false, "Prune project log files")
+	pruneCmd.Flags().BoolVar(&pruneInstall, "install", false, "Prune install-tier lib and JRE artifacts")
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd cli && go build ./...
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cli/cmd/prune.go
+git commit -m "feat: add granular prune flags (--artifacts, --rules, --jdk, --models, --logs, --install)"
+```
+
+---
+
+### Task 6: Add locking to prune command
+
+**Files:**
+- Modify: `cli/cmd/prune.go`
+- Modify: `cli/internal/utils/prune.go` (add `SkippedProject` to `PruneResult`)
+
+- [ ] **Step 1: Write failing test for skip reporting**
+
+Add to `cli/internal/utils/prune_test.go`:
+
+```go
+func TestPruneResult_AddSkipped(t *testing.T) {
+	result := &PruneResult{}
+	result.AddSkipped(SkippedProject{
+		Path: "/home/user/.opentaint/cache/my-project-abc12345",
+		Meta: LockMeta{PID: 12345, Command: "compile"},
+	})
+
+	if len(result.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped, got %d", len(result.Skipped))
+	}
+	if result.Skipped[0].Meta.PID != 12345 {
+		t.Errorf("expected PID 12345, got %d", result.Skipped[0].Meta.PID)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestPruneResult_AddSkipped" -v
+```
+Expected: FAIL — `SkippedProject`, `AddSkipped`, `Skipped` undefined
+
+- [ ] **Step 3: Add `SkippedProject` to prune types**
+
+In `cli/internal/utils/prune.go`, add:
+
+```go
+// SkippedProject represents a project cache that was skipped because a compile lock was held.
+type SkippedProject struct {
+	Path string
+	Meta LockMeta
+}
+
+// PruneResult contains the results of scanning for stale artifacts.
+type PruneResult struct {
+	Stale      []StaleArtifact
+	Skipped    []SkippedProject
+	TotalSize  int64
+	TotalCount int
+}
+
+// AddSkipped records a project that was skipped due to an active compile lock.
+func (r *PruneResult) AddSkipped(s SkippedProject) {
+	r.Skipped = append(r.Skipped, s)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd cli && go test ./internal/utils/ -run "TestPruneResult_AddSkipped" -v
+```
+Expected: PASS
+
+- [ ] **Step 5: Add lock-aware model scanning**
+
+In the models section of `ScanForStaleArtifacts`, before scanning each project cache dir, try the compile lock. If locked, skip and record. Update the models block:
+
+```go
+// Models (cache dir) — lock-aware
+if categories.has(PruneCategoryModels) {
+	modelsDir, mErr := GetModelCacheDirPath()
+	if mErr != nil {
+		output.LogDebugf("Failed to resolve model cache path: %v", mErr)
+	}
+	if info, err := os.Stat(modelsDir); err == nil && info.IsDir() {
+		modelEntries, err := os.ReadDir(modelsDir)
+		if err == nil {
+			for _, modelEntry := range modelEntries {
+				if !modelEntry.IsDir() {
+					continue
+				}
+				projectCachePath := filepath.Join(modelsDir, modelEntry.Name())
+				lockPath := CompileLockPath(projectCachePath)
+				lock, lockErr := TryLock(lockPath, LockMeta{PID: os.Getpid(), Command: "prune"})
+				if lockErr == ErrLocked {
+					meta, _ := ReadLockMeta(lockPath)
+					result.AddSkipped(SkippedProject{Path: projectCachePath, Meta: meta})
+					continue
+				}
+				if lock != nil {
+					lock.Unlock()
+				}
+				scanProjectCacheSubdirs(projectCachePath, result)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 6: Add global prune lock and skip display to `prune.go` command**
+
+In `cli/cmd/prune.go`, add locking around the Run function body:
+
+```go
+Run: func(cmd *cobra.Command, args []string) {
+	categories, err := resolveCategories()
+	if err != nil {
+		out.FatalErr(err)
+	}
+
+	// Acquire global prune lock
+	pruneLockPath, err := utils.PruneLockPath()
+	if err != nil {
+		out.Fatalf("Failed to resolve prune lock path: %s", err)
+	}
+	pruneLock, err := utils.TryLock(pruneLockPath, utils.LockMeta{
+		PID:     os.Getpid(),
+		Command: "prune",
+	})
+	if err == utils.ErrLocked {
+		out.Fatal("Another prune is already running")
+	}
+	if err != nil {
+		out.Fatalf("Failed to acquire prune lock: %s", err)
+	}
+	defer pruneLock.Unlock()
+
+	result, err := utils.ScanForStaleArtifacts(categories)
+	if err != nil {
+		out.Fatalf("Failed to scan for stale artifacts: %s", err)
+	}
+
+	// Display skipped projects
+	if len(result.Skipped) > 0 {
+		sb := out.Section("Skipped (compilation in progress)")
+		for _, s := range result.Skipped {
+			if s.Meta.PID != 0 {
+				sb.Text(fmt.Sprintf("%s (locked by PID %d)", s.Path, s.Meta.PID))
+			} else {
+				sb.Text(fmt.Sprintf("%s (locked)", s.Path))
+			}
+		}
+		sb.Render()
+	}
+
+	if result.TotalCount == 0 {
+		out.Print("No stale artifacts found. Nothing to prune.")
+		return
+	}
+
+	sb := out.Section("Stale Artifacts")
+	for _, artifact := range result.Stale {
+		sb.Text(fmt.Sprintf("%s (%s) - %s", artifact.Path, artifact.Kind, output.FormatSize(artifact.Size)))
+	}
+	sb.Line().
+		Text(fmt.Sprintf("Total: %d items, %s", result.TotalCount, output.FormatSize(result.TotalSize))).
+		Render()
+
+	if pruneDryRun {
+		out.Print("Dry run mode. No files were deleted.")
+		return
+	}
+
+	if !pruneYes {
+		if !out.Confirm("Delete these artifacts?", false) {
+			out.Print("Prune cancelled.")
+			return
+		}
+	}
+
+	if err := utils.DeleteArtifacts(result.Stale); err != nil {
+		out.Fatalf("Failed to delete artifacts: %s", err)
+	}
+
+	out.Successf("Pruned %d items, freed %s", result.TotalCount, output.FormatSize(result.TotalSize))
+},
+```
+
+Don't forget to add `"os"` to imports in `prune.go`.
+
+- [ ] **Step 7: Verify it compiles and tests pass**
+
+```bash
+cd cli && go build ./... && go test ./internal/utils/ -v
+```
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/internal/utils/prune.go cli/internal/utils/prune_test.go cli/cmd/prune.go
+git commit -m "feat: add lock-aware prune with skip reporting for active compilations"
+```
+
+---
+
+### Task 7: Replace `HasStagingDir` with compile lock in scan/compile
+
+**Files:**
+- Modify: `cli/cmd/scan.go`
+- Modify: `cli/internal/utils/model_cache.go` (remove `HasStagingDir`)
+
+- [ ] **Step 1: Replace `HasStagingDir` in `scan.go`**
+
+In `cli/cmd/scan.go`, in `resolveScanConfig()` around lines 425-429, replace:
+
+```go
+if utils.HasStagingDir(projectCachePath) {
+	out.Error("Compilation already in progress for this project")
+	suggest("To scan an existing model instead", utils.NewScanCommand("").WithProjectModel("<model-path>").Build())
+	os.Exit(1)
+}
+```
+
+With:
+
+```go
+compileLock, lockErr := utils.TryLock(
+	utils.CompileLockPath(projectCachePath),
+	utils.LockMeta{PID: os.Getpid(), Command: "compile", Project: absUserProjectRoot},
+)
+if lockErr == utils.ErrLocked {
+	out.Error("Compilation already in progress for this project")
+	suggest("To scan an existing model instead", utils.NewScanCommand("").WithProjectModel("<model-path>").Build())
+	os.Exit(1)
+}
+if lockErr != nil {
+	out.Fatalf("Failed to acquire compile lock: %s", lockErr)
+}
+```
+
+The `compileLock` must be stored in the `scanConfig` and released after compilation + promotion. Add a field to `scanConfig`:
+
+```go
+type scanConfig struct {
+	mode             ScanMode
+	absProjectModel  string
+	projectCachePath string
+	stagingDir       string
+	needsCompilation bool
+	compileLock      *utils.FileLock // non-nil when we hold the compile lock
+}
+```
+
+Release it at the end of the `scan()` function (after all operations complete):
+
+```go
+defer func() {
+	if cfg.compileLock != nil {
+		cfg.compileLock.Unlock()
+	}
+}()
+```
+
+And set it in `resolveScanConfig`:
+
+```go
+return scanConfig{
+	mode:             CompileAndScan,
+	absProjectModel:  filepath.Join(stagingDir, "project-model"),
+	projectCachePath: projectCachePath,
+	stagingDir:       stagingDir,
+	needsCompilation: true,
+	compileLock:      compileLock,
+}
+```
+
+Note: `resolveScanConfig` needs `absUserProjectRoot` as a parameter now (for the lock meta). Update its signature and the call site.
+
+- [ ] **Step 2: Remove `HasStagingDir` and `CleanupStagingDir` if unused**
+
+Remove from `cli/internal/utils/model_cache.go`:
+- `HasStagingDir` function (lines 116-127)
+- Keep `CleanupStagingDir` — it's still used by `scan.go` for cleanup on compile failure
+
+- [ ] **Step 3: Verify everything compiles**
+
+```bash
+cd cli && go build ./...
+```
+Expected: no errors
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+cd cli && go test ./...
+```
+Expected: PASS. If any tests reference `HasStagingDir`, remove those tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/cmd/scan.go cli/internal/utils/model_cache.go
+git commit -m "refactor: replace HasStagingDir heuristic with flock-based compile lock"
+```
+
+---
+
+### Task 8: Add compile lock to standalone compile command
+
+**Files:**
+- Modify: `cli/cmd/compile.go`
+
+- [ ] **Step 1: Add compile lock acquisition**
+
+The `compile` command in `compile.go` doesn't currently use the cache at all — it writes to `--output`. However, if we want compile locking to also protect the compile command when it writes to cache (via `activateLoggingForProject` which creates the project cache path), we should add locking here too.
+
+Actually, looking at `compile.go`, the standalone compile command writes to `--output` (user-specified path), not to the cache. The cache interaction only happens via `scan.go`. The compile command only uses the cache for logging.
+
+Since compile doesn't write to the model cache, no compile lock is needed here. The lock is only for cache-based compilation (scan command). Skip this task.
+
+- [ ] **Step 2: Verify compile still works**
+
+```bash
+cd cli && go build ./...
+```
+Expected: no errors
+
+- [ ] **Step 3: Commit (if any changes)**
+
+No changes expected for this task. Move on.
+
+---
+
+### Task 9: Final integration verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd cli && go test ./... -v
+```
+Expected: all PASS
+
+- [ ] **Step 2: Build the binary**
+
+```bash
+cd cli && go build -o opentaint .
+```
+Expected: binary builds successfully
+
+- [ ] **Step 3: Manual smoke test — prune with no flags**
+
+```bash
+./opentaint prune --dry-run
+```
+Expected: shows stale artifacts (or "nothing to prune"), no errors
+
+- [ ] **Step 4: Manual smoke test — prune with specific flags**
+
+```bash
+./opentaint prune --logs --dry-run
+./opentaint prune --models --dry-run
+./opentaint prune --artifacts --rules --dry-run
+```
+Expected: each shows only the relevant category
+
+- [ ] **Step 5: Manual smoke test — mutual exclusivity**
+
+```bash
+./opentaint prune --all --logs
+```
+Expected: error message about mutual exclusivity
+
+- [ ] **Step 6: Manual smoke test — prune lock**
+
+Run two prune commands simultaneously (in separate terminals):
+```bash
+# Terminal 1:
+./opentaint prune --dry-run  # should succeed
+
+# Terminal 2 (while 1 is running):
+./opentaint prune --dry-run  # should fail with "Another prune is already running"
+```
+
+- [ ] **Step 7: Commit any final fixes**
+
+If smoke tests reveal issues, fix and commit.

--- a/docs/superpowers/specs/2026-04-16-prune-lockfiles-granular-flags-design.md
+++ b/docs/superpowers/specs/2026-04-16-prune-lockfiles-granular-flags-design.md
@@ -1,0 +1,162 @@
+# Prune: Lockfiles & Granular Flags
+
+## Problem
+
+The `opentaint prune` command lacks:
+1. **Concurrency safety** — no file locking; concurrent prune/compile can corrupt state. The existing `HasStagingDir` is a best-effort TOCTOU heuristic.
+2. **Granular control** — only `--all` vs default. Users cannot selectively prune logs, models, artifacts, etc.
+3. **Log isolation** — logs live inside `cache/<slug-hash>/`, making it impossible to prune them independently of models.
+
+## Directory Structure
+
+Flat layout for JARs/rules/JDK/JRE is **unchanged**. Only the cache area is restructured — logs move to their own top-level directory:
+
+```
+~/.opentaint/
+├── analyzer_<version>.jar          # unchanged
+├── autobuilder_<version>.jar       # unchanged
+├── rules_<version>/                # unchanged
+├── jdk/                            # unchanged
+├── jre/                            # unchanged
+├── install/                        # unchanged
+│   ├── lib/
+│   ├── jre/
+│   └── .versions
+├── cache/                          # models only (no more logs here)
+│   └── <slug-hash>/
+│       ├── project-model/
+│       ├── .staging-*/
+│       └── .compile.lock           # per-project compile lock
+├── logs/                           # mirrors cache/<slug-hash> structure
+│   └── <slug-hash>/
+│       └── <timestamp>.log
+└── .prune.lock                     # global prune lock
+```
+
+### Changes from current layout
+- `logs/` becomes a top-level sibling of `cache/`, using the same `<slug-hash>` subdirs.
+- Lock files live where they protect: `.compile.lock` per project, `.prune.lock` globally.
+- No migration needed for old logs in `cache/` dirs — they get cleaned up naturally by prune.
+
+## Granular Prune Flags
+
+| Flag | Targets | Default prune | `--all` |
+|------|---------|:---:|:---:|
+| `--artifacts` | Stale analyzer + autobuilder JARs | yes | yes |
+| `--rules` | Stale rules directories | yes | yes |
+| `--jdk` | Old JDK/JRE versions | yes | yes |
+| `--models` | `cache/<slug-hash>/project-model/` + `.staging-*` | yes | yes |
+| `--logs` | `logs/<slug-hash>/` | no | yes |
+| `--install` | `install/lib/` + `install/jre/` | no | yes |
+
+### Behavior
+
+- **No flags** = default prune (artifacts, rules, jdk, models). Same as today minus `--all` stuff.
+- **`--all`** = everything including logs and install-tier.
+- **Specific flags** (e.g., `--models --logs`) = only those categories, nothing else.
+- Specific flags and `--all` are **mutually exclusive** — error if combined.
+
+Examples:
+```bash
+opentaint prune                    # default: artifacts + rules + jdk + models
+opentaint prune --logs             # only logs
+opentaint prune --models --logs    # models and logs
+opentaint prune --all              # everything
+opentaint prune --all --logs       # error: mutually exclusive
+```
+
+## Locking
+
+### Dependency
+
+`github.com/gofrs/flock` — cross-platform file locking (flock on Unix, LockFileEx on Windows). Auto-releases on process crash.
+
+### Lock scopes
+
+| Lock | File | Acquired by | Purpose |
+|------|------|-------------|---------|
+| Global prune | `~/.opentaint/.prune.lock` | `prune` command | Prevent concurrent prunes |
+| Per-project compile | `cache/<slug-hash>/.compile.lock` | `scan`/`compile` | Protect active compilations |
+
+### Lock file content (diagnostics)
+
+```
+pid=12345
+command=compile
+project=/Users/dev/my-app
+```
+
+PID and metadata written after acquiring the lock. Used for skip reporting only — not part of the locking mechanism itself.
+
+### Prune flow
+
+1. Try exclusive non-blocking lock on `.prune.lock`.
+   - If held: fail fast with "Another prune is already running".
+2. Scan for stale artifacts across all requested categories.
+3. For each project in `cache/`, try non-blocking lock on `.compile.lock`.
+   - Acquired: include project in prune candidates, release (re-acquire at delete time).
+   - Locked: skip project, add to "skipped" report.
+4. Display results + skipped projects.
+5. If not dry-run and user confirms: delete artifacts (re-acquiring per-project locks before removing).
+6. Release `.prune.lock`.
+
+### Compile flow
+
+1. Acquire exclusive lock on `cache/<slug-hash>/.compile.lock`.
+   - If held: fail with "Compilation already in progress for this project".
+2. Create staging dir, compile, promote to cache.
+3. Write logs to `logs/<slug-hash>/`.
+4. Release lock.
+
+This replaces the `HasStagingDir` heuristic entirely.
+
+### Skip reporting
+
+When prune skips locked projects:
+```
+Skipped (compilation in progress):
+  ~/.opentaint/cache/my-app-a1b2c3d4 (locked by PID 12345)
+
+Stale Artifacts:
+  ~/.opentaint/analyzer_0.9.0.jar (artifacts) - 250.5 MB
+  Total: 1 item, 250.5 MB
+```
+
+## Migration & Backward Compatibility
+
+### Logs
+
+- `scan`/`compile` commands updated to write logs to `logs/<slug-hash>/`.
+- No automatic migration of old logs from `cache/<slug-hash>/`.
+- Old logs inside cache dirs are treated as part of the model cache for pruning — cleaned up by `--models` or `--all`.
+
+### HasStagingDir removal
+
+- `HasStagingDir()` removed entirely; replaced by flock-based compile lock.
+- `.staging-*` directories still used for the staging workflow itself.
+
+### No breaking changes
+
+- Flat artifact layout unchanged.
+- JDK/JRE storage unchanged.
+- Install-tier unchanged.
+- Project model cache paths unchanged.
+- `opentaint prune` with no flags behaves identically to today's default.
+
+## File Changes
+
+### New files
+- `cli/internal/utils/lock.go` — lock acquisition/release helpers, PID content, skip reporting.
+- `cli/internal/utils/lock_test.go` — lock tests.
+
+### Modified files
+- `cli/internal/utils/prune.go` — granular category scanning, lock-aware flow.
+- `cli/internal/utils/prune_test.go` — tests for new flags and locking.
+- `cli/cmd/prune.go` — new flags, mutual exclusivity validation, skip reporting output.
+- `cli/internal/utils/model_cache.go` — remove `HasStagingDir`, add log path helpers.
+- `cli/cmd/scan.go` — compile lock instead of `HasStagingDir`, write logs to new location.
+- `cli/cmd/compile.go` — same lock changes as scan.
+- `go.mod` / `go.sum` — add `github.com/gofrs/flock`.
+
+### Removed
+- `HasStagingDir()` function.


### PR DESCRIPTION
  - Rework `prune` to correctly scope what gets deleted based on `--all` flag:
    - Without `--all`: prunes only `project-model/` and `.staging-*` dirs within project cache, preserving logs
    - With `--all`: prunes entire project cache directories (including logs) and install-tier artifacts
    - Fixes size double-counting where log sizes were reported twice
  - Rework `self-update` to detect installation method (Homebrew vs binary) and update artifacts in-place
  respecting the installation style (bundled vs install-tier)
  - Merge `--include-logs` into `--all` flag for simpler UX
  - Add `GetOpenTaintHomePath()` for read-only contexts (no side-effect directory creation)
  - Fix: `install-lib` is now only pruned with `--all` flag