### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
-analyzer: "analyzer/2026.04.22.3d3d9a7"
+analyzer: "analyzer/2026.04.22.db77b75"
 autobuilder: "autobuilder/2026.03.19.adeb616"
 rules: "rules/v0.1.1"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **analyzer**: `analyzer/2026.04.22.3d3d9a7` → `analyzer/2026.04.22.db77b75`


_Automated by the Update CLI Versions workflow._
