### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
 analyzer: "analyzer/2026.05.13.ac3cefb"
-autobuilder: "autobuilder/2026.03.19.adeb616"
+autobuilder: "autobuilder/2026.05.13.5f5fa4e"
 rules: "rules/v0.1.1"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **autobuilder**: `autobuilder/2026.03.19.adeb616` → `autobuilder/2026.05.13.5f5fa4e`


_Automated by the Update CLI Versions workflow._
