### PR TITLE
fix(cli): Suppress update banner after running update command

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -53,8 +53,11 @@ var rootCmd = &cobra.Command{
 		// Reconcile install-tier version marker if needed (lightweight: a few Stat calls).
 		utils.ReconcileInstallMarker()
 
-		// Start async update check (non-blocking, at most once per day)
-		if !globals.Config.Output.Quiet {
+		// Start async update check (non-blocking, at most once per day).
+		// Skip for the update command itself: the running process holds the OLD
+		// version, so the check would queue an "update available" hint for the
+		// version the user is in the process of installing.
+		if !globals.Config.Output.Quiet && cmd.Name() != "update" {
 			go checkForUpdateAsync()
 		}
 


### PR DESCRIPTION
PersistentPreRunE always spawned an async check that read the running binary's version. During `opentaint update`, that version is still the OLD one, so the check queued an "update available" hint for the very version being installed; PersistentPostRun then printed the banner after the successful update, telling the user to run the command they just ran.

Skip the async check entirely when the subcommand is `update`, so no hint is ever queued for this command.