### PR TITLE
fix(ci): Surface install.ps1 failures in test-install-ps1

### DIFF
--- a/.github/workflows/ci-cli.yaml
+++ b/.github/workflows/ci-cli.yaml
@@ -398,9 +398,15 @@ jobs:
           Start-Process -NoNewWindow python -ArgumentList "-m", "http.server", "8080" -WorkingDirectory cli
           Start-Sleep -Seconds 2
           $output = pwsh -File scripts/install/install.ps1 2>&1 | Out-String
-          $output -match 'OPENTAINT_BINARY_PATH=(.+)'
-          $binaryPath = $matches[1]
-          Write-Host "::set-output name=OPENTAINT_BINARY_PATH::$binaryPath"
+          Write-Host $output
+          if ($LASTEXITCODE -ne 0) {
+            throw "install.ps1 exited with code $LASTEXITCODE"
+          }
+          if ($output -notmatch 'OPENTAINT_BINARY_PATH=(.+)') {
+            throw "install.ps1 did not emit OPENTAINT_BINARY_PATH"
+          }
+          $binaryPath = $Matches[1].Trim()
+          "OPENTAINT_BINARY_PATH=$binaryPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
       - name: Verify installation
         shell: pwsh
         run: |


### PR DESCRIPTION
The Windows install test captured install.ps1 output into a variable but never printed it, then unconditionally indexed $matches[1]. When install.ps1 failed to emit OPENTAINT_BINARY_PATH (for any reason), the step failed with the cryptic "Cannot index into a null array" instead of the actual install.ps1 error.

- Echo install.ps1 output before parsing it.
- Throw on non-zero $LASTEXITCODE from install.ps1.
- Throw a clear message when the regex match fails.
- Trim captured path and write via $env:GITHUB_OUTPUT (the deprecated ::set-output workflow command was being used).