### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
-analyzer: "analyzer/2026.06.05.d30859e"
-autobuilder: "autobuilder/2026.06.05.d30859e"
+analyzer: "analyzer/2026.06.09.fc56601"
+autobuilder: "autobuilder/2026.06.09.fc56601"
 rules: "rules/v0.2.0"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **autobuilder**: `autobuilder/2026.06.05.d30859e` → `autobuilder/2026.06.09.fc56601`


_Automated by the Update CLI Versions workflow._
