### PR TITLE
fix(cli): Write rule load trace to ~/.opentaint logs dir

### DIFF
--- a/cli/cmd/scan.go
+++ b/cli/cmd/scan.go
@@ -245,11 +245,16 @@ func runScan(cmd *cobra.Command, cfg ScanConfig) {
 
 	uriBase := fmt.Sprintf("%s%s", sourceRoot, string(filepath.Separator))
 
+	ruleLoadTraceDir, err := utils.GetProjectLogPath(absUserProjectRoot)
+	if err != nil {
+		out.Fatalf("Failed to resolve rule load trace directory: %v", err)
+	}
+
 	var absSemgrepRuleLoadTracePath string
 	if cfg.DryRun {
-		absSemgrepRuleLoadTracePath = filepath.Join(os.TempDir(), dryRunRuleLoadTraceFileName)
+		absSemgrepRuleLoadTracePath = filepath.Join(ruleLoadTraceDir, dryRunRuleLoadTraceFileName)
 	} else {
-		absSemgrepRuleLoadTracePath = setupSemgrepRuleLoadTrace()
+		absSemgrepRuleLoadTracePath = setupSemgrepRuleLoadTrace(ruleLoadTraceDir)
 	}
 
 	// Display scan information in tree format
@@ -564,8 +569,8 @@ func printScanInfo(cmd *cobra.Command, plan scanPlan, absSemgrepRuleLoadTracePat
 	sb.Render()
 }
 
-func setupSemgrepRuleLoadTrace() string {
-	absSemgrepRuleLoadTracePath, err := load_trace.GenerateSemgrepRuleLoadTraceFilePath()
+func setupSemgrepRuleLoadTrace(traceDir string) string {
+	absSemgrepRuleLoadTracePath, err := load_trace.RuleLoadTracePathIn(traceDir)
 	if err != nil {
 		out.Fatalf("Failed to generate rule load trace file path: \"%s\": %v", absSemgrepRuleLoadTracePath, err)
 	}

--- a/cli/internal/load_trace/gen_rule_load_trace_file_name.go
+++ b/cli/internal/load_trace/gen_rule_load_trace_file_name.go
@@ -19,9 +19,6 @@ type PathBuilder struct {
 // NewPathBuilder creates a new PathBuilder with default settings
 func NewPathBuilder() *PathBuilder {
 	return &PathBuilder{
-		baseDir:     os.TempDir(),
-		subDir:      filepath.Join("opentaint", "rule_load_trace"),
-		filePrefix:  "",
 		fileSuffix:  ".json",
 		timeFormat:  "2006-01-02_15-04-05",
 		permissions: 0755,
@@ -77,7 +74,8 @@ func (pb *PathBuilder) Build() (string, error) {
 	return filePath, nil
 }
 
-// GenerateSemgrepRuleLoadTraceFilePath creates a trace file path using default settings (backward compatibility)
-func GenerateSemgrepRuleLoadTraceFilePath() (string, error) {
-	return NewPathBuilder().Build()
+// RuleLoadTracePathIn builds a rule-load-trace file path inside dir, e.g.
+// <dir>/rule-load-trace-2006-01-02_15-04-05.json, creating dir if needed.
+func RuleLoadTracePathIn(dir string) (string, error) {
+	return NewPathBuilder().BaseDir(dir).FilePrefix("rule-load-trace-").Build()
 }


### PR DESCRIPTION
The rule load trace was written under os.TempDir(). Store it in the per-project log directory (~/.opentaint/logs/<slug-hash>/) so it lives alongside the logs and is cleaned up by `opentaint prune --logs`.

Encapsulate the trace-file naming convention in the load_trace lib via RuleLoadTracePathIn, keeping the cmd call site free of filename details, and drop the now-unused tmp PathBuilder defaults.