### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
 analyzer: "analyzer/2026.06.18.a86a157"
-autobuilder: "autobuilder/2026.06.11.1fd5326"
+autobuilder: "autobuilder/2026.06.18.e9476cf"
 rules: "rules/v0.2.0"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **autobuilder**: `autobuilder/2026.06.11.1fd5326` → `autobuilder/2026.06.18.e9476cf`


_Automated by the Update CLI Versions workflow._
