### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
-analyzer: "analyzer/2026.07.01.31496ce"
+analyzer: "analyzer/2026.07.02.7b1cc4d"
 autobuilder: "autobuilder/2026.06.18.e9476cf"
 rules: "rules/v0.2.2"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **analyzer**: `analyzer/2026.07.01.31496ce` → `analyzer/2026.07.02.7b1cc4d`


_Automated by the Update CLI Versions workflow._
