### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
-analyzer: "analyzer/2026.07.17.deb825c"
+analyzer: "analyzer/2026.07.18.a4b63ce"
 autobuilder: "autobuilder/2026.07.16.7a834a0"
 rules: "rules/v0.2.2"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **analyzer**: `analyzer/2026.07.17.deb825c` → `analyzer/2026.07.18.a4b63ce`


_Automated by the Update CLI Versions workflow._
