### PR TITLE
fix(cli): Update bundled dependency versions

### DIFF
--- a/cli/internal/globals/versions.yaml
+++ b/cli/internal/globals/versions.yaml
@@ -1,4 +1,4 @@
-analyzer: "analyzer/2026.07.30.6adc217"
+analyzer: "analyzer/2026.08.01.a8995a6"
 autobuilder: "autobuilder/2026.07.16.7a834a0"
 rules: "rules/v0.3.0"
 java: 21


### PR DESCRIPTION
## Updated dependency versions

- **analyzer**: `analyzer/2026.07.30.6adc217` → `analyzer/2026.08.01.a8995a6`


_Automated by the Update CLI Versions workflow._
