### PR TITLE
fix(analyzer): Match Go generic calls with qualified type arguments

### DIFF
--- a/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/rules/TypeUtils.kt
+++ b/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/rules/TypeUtils.kt
@@ -93,7 +93,15 @@ private fun <T> List<T>.endsWith(other: List<T>): Boolean {
 }
 
 fun String.splitFullName(): Pair<String, String> {
-    val simpleName = substringAfterLast('.')
-    val pkgName = substringBeforeLast('.', "")
-    return pkgName to simpleName
+    var bracketDepth = 0
+    for (index in lastIndex downTo 0) {
+        when (this[index]) {
+            ']' -> bracketDepth++
+            '[' -> bracketDepth--
+            '.' -> if (bracketDepth == 0) {
+                return substring(0, index) to substring(index + 1)
+            }
+        }
+    }
+    return "" to this
 }

--- a/core/opentaint-dataflow-core/opentaint-go-dataflow/src/test/kotlin/org/opentaint/dataflow/go/rules/TypeUtilsTest.kt
+++ b/core/opentaint-dataflow-core/opentaint-go-dataflow/src/test/kotlin/org/opentaint/dataflow/go/rules/TypeUtilsTest.kt
@@ -4,6 +4,7 @@ import org.opentaint.ir.go.type.GoIRNamedTypeRef
 import org.opentaint.ir.go.type.GoIRPointerType
 import org.opentaint.ir.go.type.NamedTypeRef
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -35,5 +36,31 @@ class TypeUtilsTest {
     @Test
     fun `mismatched simple name does not match`() {
         assertFalse(matchesType(ptr("os/exec", "Cmd"), "*os/exec.Other"))
+    }
+
+    @Test
+    fun `split package function name`() {
+        assertEquals("strings" to "Clone", "strings.Clone".splitFullName())
+        assertEquals("github.com/acme/pkg" to "Clone", "github.com/acme/pkg.Clone".splitFullName())
+        assertEquals("" to "make", "make".splitFullName())
+    }
+
+    @Test
+    fun `split generic function with qualified type arguments`() {
+        val name = "test/util.GenericIdentity[test/model.NamedString]"
+        assertEquals("test/util" to "GenericIdentity[test/model.NamedString]", name.splitFullName())
+    }
+
+    @Test
+    fun `split generic function with nested qualified type arguments`() {
+        val name = "test/util.Clone[[]test/model.Box[test/inner.Value] test/model.Box[test/inner.Value]]"
+        val function = "Clone[[]test/model.Box[test/inner.Value] test/model.Box[test/inner.Value]]"
+        assertEquals("test/util" to function, name.splitFullName())
+    }
+
+    @Test
+    fun `split method on generic receiver`() {
+        val name = "(*test/util.Box[test/model.Value]).Get"
+        assertEquals("(*test/util.Box[test/model.Value])" to "Get", name.splitFullName())
     }
 }

--- a/core/samples/src/main/go/pass_through.go
+++ b/core/samples/src/main/go/pass_through.go
@@ -1,6 +1,6 @@
 package test
-import "test/util"
 
+import "test/util"
 
 // ── Pass-through rule tests ──────────────────────────────────────────
 
@@ -25,4 +25,20 @@ func passThrough003T() {
 func passThrough004F() {
 	result := util.Transform("clean", util.Source())
 	util.Sink(result)
+}
+
+func passThrough005T() {
+	result := util.GenericIdentity[string](util.Source())
+	util.Sink(result)
+}
+
+func passThrough006T() {
+	data := util.NamedString(util.Source())
+	util.Sink(string(data))
+}
+
+func passThrough007T() {
+	data := util.NamedString(util.Source())
+	result := util.GenericIdentity[util.NamedString](data)
+	util.Sink(string(result))
 }

--- a/core/samples/src/main/go/util/util.go
+++ b/core/samples/src/main/go/util/util.go
@@ -28,6 +28,10 @@ func Passthrough(data string) string          { return data }
 func Sanitize(data string) string             { return "clean" }
 func Transform(in1 string, in2 string) string { return in2 }
 
+type NamedString string
+
+func GenericIdentity[T any](value T) T { return value }
+
 // Collection Sources (whole container tainted via Result position)
 func SourceSlice() []string        { return []string{"tainted"} }
 func SourceMap() map[string]string { return map[string]string{"k": "tainted"} }

--- a/core/src/test/kotlin/org/opentaint/go/sast/dataflow/PassThroughTest.kt
+++ b/core/src/test/kotlin/org/opentaint/go/sast/dataflow/PassThroughTest.kt
@@ -7,11 +7,27 @@ import org.opentaint.dataflow.configuration.go.serialized.GoSerializedRule
 import org.opentaint.dataflow.configuration.jvm.serialized.PositionBase.Argument
 import org.opentaint.dataflow.configuration.jvm.serialized.PositionBase.Result
 import org.opentaint.dataflow.configuration.jvm.serialized.PositionBaseWithModifiers
+import org.opentaint.ir.go.cfg.GoIRCallTarget
+import org.opentaint.ir.go.ext.findFunctionByFullName
+import org.opentaint.ir.go.inst.GoIRCall
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PassThroughTest : AnalysisTest() {
+
+    private fun genericPassthroughRule(functionName: String) = GoSerializedRule.PassThrough(
+        pkg = GoNameMatcher.Simple("test/util"),
+        function = GoNameMatcher.Simple(functionName),
+        copy = listOf(
+            GoSerializedPassAction(
+                from = PositionBaseWithModifiers.BaseOnly(Argument(0)),
+                to = PositionBaseWithModifiers.BaseOnly(Result),
+            ),
+        ),
+        info = null,
+    )
 
     private val passthroughRule = GoSerializedRule.PassThrough(
         pkg = GoNameMatcher.Simple("util"),
@@ -51,5 +67,28 @@ class PassThroughTest : AnalysisTest() {
     @Test fun passThrough003T() {
         val vulns = runAnalysis(stdSource, stdSink, "test.passThrough003T", extraPassRules = listOf(transformRule))
         assertTrue(vulns.isNotEmpty(), "Sink was not reached in test.passThrough003T")
+    }
+
+    @Test fun passThrough005T() {
+        val rule = genericPassthroughRule("GenericIdentity[string]")
+        val vulns = runAnalysis(stdSource, stdSink, "test.passThrough005T", extraPassRules = listOf(rule))
+        assertTrue(vulns.isNotEmpty(), "Sink was not reached in test.passThrough005T")
+    }
+
+    @Test fun passThrough006T() {
+        assertReachable("test.passThrough006T")
+    }
+
+    @Test fun passThrough007T() {
+        val entryPoint = cp.findFunctionByFullName("test.passThrough007T")!!
+        val callee = entryPoint.body!!.instructions
+            .filterIsInstance<GoIRCall>()
+            .mapNotNull { (it.call.target as? GoIRCallTarget.Function)?.function?.fullName }
+            .single { it.contains("GenericIdentity") }
+        assertEquals("test/util.GenericIdentity[test/util.NamedString]", callee)
+
+        val rule = genericPassthroughRule("GenericIdentity[test/util.NamedString]")
+        val vulns = runAnalysis(stdSource, stdSink, "test.passThrough007T", extraPassRules = listOf(rule))
+        assertTrue(vulns.isNotEmpty(), "Sink was not reached in test.passThrough007T")
     }
 }


### PR DESCRIPTION
Go SSA includes instantiated type arguments in function names. For a call such as `test/util.GenericIdentity[test/model.NamedString]`, the previous implementation split the name at the last `.`, which belongs to the type argument. This produced an invalid package/function pair and prevented the pass-through model from matching.

The fix ignores dots inside generic type argument brackets when splitting function names.

Tests added:

- 3 positive Go dataflow cases for builtin and package-qualified type arguments;
- `splitFullName` tests for regular functions, qualified and nested generic arguments, and generic receivers.