### PR TITLE
fix(analyzer): Normalize Go method parameter aliases

### DIFF
--- a/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/GoFlowFunctionUtils.kt
+++ b/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/GoFlowFunctionUtils.kt
@@ -81,18 +81,23 @@ object GoFlowFunctionUtils {
         value: GoIRValue,
         method: GoIRFunction?
     ): AccessPathBase = when (value) {
-        is GoIRParameterValue -> {
-            if (method != null && method.isMethod && value.paramIndex == 0) {
-                AccessPathBase.This
-            } else {
-                val shift = if (method != null && method.isMethod) 1 else 0
-                AccessPathBase.Argument(value.paramIndex - shift)
-            }
-        }
+        is GoIRParameterValue -> parameterAccessPathBase(value.paramIndex, method)
 
         is GoIRRegister -> AccessPathBase.LocalVar(value.index)
         is GoIRConstValue -> AccessPathBase.Constant(value.type.displayName, value.value.toString())
         else -> error("Unexpected value: $value")
+    }
+
+    fun parameterAccessPathBase(
+        parameterIndex: Int,
+        method: GoIRFunction?
+    ): AccessPathBase {
+        val hasReceiver = method?.isMethod == true
+        return if (hasReceiver && parameterIndex == 0) {
+            AccessPathBase.This
+        } else {
+            AccessPathBase.Argument(parameterIndex - if (hasReceiver) 1 else 0)
+        }
     }
 
     fun accessForGlobal(global: GoIRGlobal) = RefAccess(

--- a/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/analysis/alias/GoLocalAliasAnalysis.kt
+++ b/core/opentaint-dataflow-core/opentaint-go-dataflow/src/main/kotlin/org/opentaint/dataflow/go/analysis/alias/GoLocalAliasAnalysis.kt
@@ -16,6 +16,7 @@ import org.opentaint.dataflow.ap.ifds.analysis.alias.LocalAliasAnalysis
 import org.opentaint.dataflow.ap.ifds.analysis.alias.State
 import org.opentaint.dataflow.ap.ifds.analysis.alias.allElements
 import org.opentaint.dataflow.ap.ifds.analysis.alias.withAnalysisCancellation
+import org.opentaint.dataflow.go.GoFlowFunctionUtils
 import org.opentaint.dataflow.go.analysis.alias.GoDSUAliasAnalysis.ConnectedAliases
 import org.opentaint.dataflow.util.forEachInt
 import org.opentaint.ir.api.common.cfg.CommonInst
@@ -196,7 +197,10 @@ class GoLocalAliasAnalysis(
         return when (info) {
             is GoLocalAlias.SimpleLoc -> when (val loc = info.loc) {
                 is GoRefValue.Local -> AliasApInfoNoRef(AccessPathBase.LocalVar(loc.idx), emptyList())
-                is GoRefValue.Arg -> AliasApInfoNoRef(AccessPathBase.Argument(loc.idx), emptyList())
+                is GoRefValue.Arg -> AliasApInfoNoRef(
+                    GoFlowFunctionUtils.parameterAccessPathBase(loc.idx, function),
+                    emptyList()
+                )
                 is GoRefValue.Global -> AliasApInfoNoRef(AccessPathBase.ClassStatic, listOf(GoAliasAccessor.Global(loc.name)))
                 is GoRefValue.FreeVarBase -> AliasApInfoNoRef(AccessPathBase.This, emptyList())
             }

--- a/core/opentaint-go-querylang/samples-go/MethodInterfaceSourceAliasReboxing/rule.yaml
+++ b/core/opentaint-go-querylang/samples-go/MethodInterfaceSourceAliasReboxing/rule.yaml
@@ -1,0 +1,37 @@
+rules:
+  - id: method-interface-source-alias-reboxing
+    languages: [go]
+    severity: WARNING
+    message: "Admitted request reaches RaftApply"
+    mode: join
+    join:
+      refs:
+        - rule: '#method-alias-source'
+          as: src
+        - rule: '#method-alias-sink'
+          as: sink
+      on:
+        - 'src.$UNTRUSTED -> sink.$UNTRUSTED'
+  - id: method-alias-source
+    options: {lib: true}
+    languages: [go]
+    severity: NOTE
+    message: "Request is admitted"
+    mode: taint
+    pattern-sources:
+      - label: "$UNTRUSTED"
+        patterns:
+          - pattern-either:
+              - pattern: "($S : *MethodInterfaceSourceAliasReboxing.Server).Authenticate($CTX, $UNTRUSTED)"
+              - pattern: "($S : *MethodInterfaceSourceAliasReboxing.Server).AuthenticateConcrete($CTX, $UNTRUSTED)"
+          - focus-metavariable: $UNTRUSTED
+  - id: method-alias-sink
+    options: {lib: true}
+    languages: [go]
+    severity: NOTE
+    message: "Request reaches RaftApply"
+    mode: taint
+    pattern-sinks:
+      - patterns:
+          - pattern: "($S : *MethodInterfaceSourceAliasReboxing.Server).RaftApply($TYPE, $UNTRUSTED)"
+          - focus-metavariable: $UNTRUSTED

--- a/core/opentaint-go-querylang/samples-go/MethodInterfaceSourceAliasReboxing/sample.go
+++ b/core/opentaint-go-querylang/samples-go/MethodInterfaceSourceAliasReboxing/sample.go
@@ -1,0 +1,49 @@
+package util
+
+type Request struct{}
+
+func (*Request) AdmittedRequest() {}
+
+type Admitted interface {
+	AdmittedRequest()
+}
+
+type Server struct{}
+
+type Context struct{}
+
+func (*Server) Authenticate(*Context, Admitted)         {}
+func (*Server) AuthenticateConcrete(*Context, *Request) {}
+func (*Server) RaftApply(int, any)                      {}
+
+type Endpoint struct{}
+
+func Positive_free_function(args *Request) {
+	server := &Server{}
+	server.Authenticate(nil, args)
+	server.RaftApply(0, args)
+}
+
+func (*Endpoint) Positive_method_concrete_source(args *Request) {
+	server := &Server{}
+	server.AuthenticateConcrete(nil, args)
+	server.RaftApply(0, args)
+}
+
+func (*Endpoint) Positive_method_reuses_source_interface(args *Request) {
+	server := &Server{}
+	admitted := Admitted(args)
+	server.Authenticate(nil, admitted)
+	server.RaftApply(0, admitted)
+}
+
+func (*Endpoint) Positive_method_parameter_reboxed(args *Request) {
+	server := &Server{}
+	server.Authenticate(nil, args)
+	server.RaftApply(0, args)
+}
+
+func (*Endpoint) Negative_no_admission(args *Request) {
+	server := &Server{}
+	server.RaftApply(0, args)
+}

--- a/core/opentaint-go-querylang/src/test/kotlin/org/opentaint/semgrep/GoSampleBasedTest.kt
+++ b/core/opentaint-go-querylang/src/test/kotlin/org/opentaint/semgrep/GoSampleBasedTest.kt
@@ -12,6 +12,8 @@ class GoSampleBasedTest: GoSampleBasedTestBase("GO_SAMPLES_DIR") {
 
     @Test fun passThrough() = runSample("PassThrough")
 
+    @Test fun methodInterfaceSourceAliasReboxing() = runSample("MethodInterfaceSourceAliasReboxing")
+
     @Test fun sanitizer() = runSample("Sanitizer")
 
     @Test fun multiArgSink() = runSample("MultiArgSink")


### PR DESCRIPTION
Go SSA numbers the receiver as parameter 0 and explicit method arguments from parameter 1. OpenTaint represents the receiver as `This` and explicit arguments from `Argument(0)`. Alias analysis used raw SSA indices, so the same method argument could become `Argument(1)` in alias flow and `Argument(0)` in normal flow, losing taint between interface conversions.

The fix introduces one receiver-aware parameter conversion shared by normal flow and alias analysis.

Tests added:

- free-function control;
- concrete method argument control;
- reused interface value control;
- separate interface reboxing regression;
- negative case without an admission source.