### PR TITLE
test(analyzer): Reproduce unresolved Go func-field factory calls

### DIFF
--- a/core/opentaint-go-querylang/samples-go/DynamicFactoryCallResolution/rule.yaml
+++ b/core/opentaint-go-querylang/samples-go/DynamicFactoryCallResolution/rule.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: dynamic-factory-call-resolution
+    languages: [go]
+    severity: WARNING
+    message: "Input.ID reaches Sink through a factory-created object"
+    mode: taint
+    pattern-sources:
+      - pattern: "($I : *DynamicFactoryCallResolution.Input).ID"
+    pattern-sinks:
+      - patterns:
+          - pattern: "DynamicFactoryCallResolution.Sink($UNTRUSTED)"
+          - focus-metavariable: $UNTRUSTED

--- a/core/opentaint-go-querylang/samples-go/DynamicFactoryCallResolution/sample.go
+++ b/core/opentaint-go-querylang/samples-go/DynamicFactoryCallResolution/sample.go
@@ -1,0 +1,107 @@
+package util
+
+type Input struct {
+	ID    string
+	Clean string
+}
+
+func Sink(string) {}
+
+type Runner interface {
+	Run()
+}
+
+type ConcreteRunner struct {
+	Path string
+}
+
+func (r *ConcreteRunner) Run() {
+	Sink(r.Path)
+}
+
+func NewConcrete(in *Input) *ConcreteRunner {
+	return &ConcreteRunner{Path: in.ID}
+}
+
+func NewInterface(in *Input) Runner {
+	return &ConcreteRunner{Path: in.ID}
+}
+
+func NewClean(in *Input) *ConcreteRunner {
+	return &ConcreteRunner{Path: in.Clean}
+}
+
+type ConcreteFactory func(*Input) *ConcreteRunner
+type InterfaceResultFactory func(*Input) Runner
+
+type Client struct {
+	ConcreteFactory        ConcreteFactory
+	InterfaceResultFactory InterfaceResultFactory
+}
+
+func NewClient() *Client {
+	return &Client{
+		ConcreteFactory:        NewConcrete,
+		InterfaceResultFactory: NewInterface,
+	}
+}
+
+var defaultClient = NewClient()
+
+type FactoryObject interface {
+	Create(*Input) *ConcreteRunner
+}
+
+type ConcreteFactoryObject struct{}
+
+func (*ConcreteFactoryObject) Create(in *Input) *ConcreteRunner {
+	return &ConcreteRunner{Path: in.ID}
+}
+
+type InterfaceClient struct {
+	Factory FactoryObject
+}
+
+func Positive_direct_field_source(in *Input) {
+	Sink(in.ID)
+}
+
+func Positive_direct_named_factory(in *Input) {
+	runner := NewConcrete(in)
+	runner.Run()
+}
+
+func Positive_locally_initialized_func_field(in *Input) {
+	client := &Client{ConcreteFactory: NewConcrete}
+	runner := client.ConcreteFactory(in)
+	runner.Run()
+}
+
+func Positive_constructor_then_method(in *Input) {
+	client := NewClient()
+	client.Positive_opaque_concrete_func_field(in)
+}
+
+func (client *InterfaceClient) Positive_opaque_interface_method(in *Input) {
+	runner := client.Factory.Create(in)
+	runner.Run()
+}
+
+func (client *Client) Positive_opaque_concrete_func_field(in *Input) {
+	runner := client.ConcreteFactory(in)
+	runner.Run()
+}
+
+func (client *Client) Positive_opaque_interface_result_func_field(in *Input) {
+	runner := client.InterfaceResultFactory(in)
+	runner.Run()
+}
+
+func Positive_package_initialized_global(in *Input) {
+	defaultClient.Positive_opaque_concrete_func_field(in)
+}
+
+func Negative_clean_field(in *Input) {
+	runner := NewClean(in)
+	runner.Run()
+}

--- a/core/opentaint-go-querylang/src/test/kotlin/org/opentaint/semgrep/GoSampleBasedTest.kt
+++ b/core/opentaint-go-querylang/src/test/kotlin/org/opentaint/semgrep/GoSampleBasedTest.kt
@@ -12,6 +12,8 @@ class GoSampleBasedTest: GoSampleBasedTestBase("GO_SAMPLES_DIR") {
 
     @Test fun passThrough() = runSample("PassThrough")
 
+    @Test fun dynamicFactoryCallResolution() = runSample("DynamicFactoryCallResolution")
+
     @Test fun sanitizer() = runSample("Sanitizer")
 
     @Test fun multiArgSink() = runSample("MultiArgSink")


### PR DESCRIPTION
Go dynamic calls through function-valued fields are resolved when the field assignment is visible locally. When the field belongs to an opaque receiver or is reached through a package-initialized global, the factory function is missing from the callee set. Taint therefore does not enter the returned object and the later sink is missed.

Tests added:

- direct named factory and local function-field controls;
- constructor-to-method and interface-dispatch controls;
- opaque concrete and interface-return function-field cases;
- package-initialized global case;
- clean negative case.